### PR TITLE
Fix USB PCI string matching regex

### DIFF
--- a/scripts/start_civ.sh
+++ b/scripts/start_civ.sh
@@ -295,7 +295,7 @@ function set_pt_pci_vfio() {
 }
 
 function set_pt_usb() {
-    local USB_PCI=$(lspci -D |grep "USB controller.*xHCI" | grep -o "....:..:..\..")
+    local USB_PCI=$(lspci -D |grep "USB controller" | grep -o "....:..:..\..")
     echo "passthrough USB device: $USB_PCI"
 
     if [[ $1 == "unset" ]]; then


### PR DESCRIPTION
Since the USB driver might different on different platform, so remove
"xHCI" from the matching regex.

Tracked-On: OAM-91975
Signed-off-by: Qi, Yadong <yadong.qi@intel.com>