### PR TITLE
tui: update scroll symbol only when key up/down

### DIFF
--- a/src/guest/tui.c
+++ b/src/guest/tui.c
@@ -572,6 +572,7 @@ static int key_form_driver(int ch)
 			form_driver(form, REQ_END_LINE);
 			set_field_back(form->current, COLOR_PAIR(WHITE_BLUE));
 		}
+		update_scroll_symbol();
 		break;
 	case KEY_UP:
 		if (form->current == field[1]) {
@@ -588,6 +589,7 @@ static int key_form_driver(int ch)
 			form_driver(form, REQ_END_LINE);
 			set_field_back(form->current, COLOR_PAIR(WHITE_BLUE));
 		}
+		update_scroll_symbol();
 		break;
 	case KEY_LEFT:
 		if (field_opts(form->current) & O_EDIT)
@@ -626,8 +628,6 @@ static int key_form_driver(int ch)
 		form_driver(form, ch);
 		break;
 	}
-
-	update_scroll_symbol();
 
 	return ret;
 }


### PR DESCRIPTION
It might break some normal input if update scroll
symbol on all key events.

Tracked-On: OAM-91978
Signed-off-by: Qi, Yadong <yadong.qi@intel.com>