### PR TITLE
vm_manager: Fix issue with battery and thermal mediation

### DIFF
--- a/scripts/start_civ.sh
+++ b/scripts/start_civ.sh
@@ -507,11 +507,11 @@ function parse_arg() {
                 ;;
 
             --thermal-mediation)
-                set_thermal_mediation
+                setup_thermal_mediation
                 ;;
 
             --battery-mediation)
-                set_battery_mediation
+                setup_battery_mediation
                 ;;
 
             --guest-pm-control)


### PR DESCRIPTION
The function definitions and function calls for
battery and thermal mediation do not match.
This patch fixes the function call to match with
function definition.

Tracked-On: OAM-91989
Signed-off-by: saranya <saranya.gopal@intel.com>