### PR TITLE
vm_manager: Make USB PT work for CML NUC

### DIFF
--- a/scripts/start_civ.sh
+++ b/scripts/start_civ.sh
@@ -302,7 +302,7 @@ function set_pt_pci_vfio() {
 }
 
 function set_pt_usb() {
-    local USB_PCI=$(lspci -D |grep "USB controller" | grep -o "....:..:..\..")
+    local USB_PCI=$(lspci -D |grep "USB controller" | grep -v "Thunderbolt" | grep -o "....:..:..\..")
     echo "passthrough USB device: $USB_PCI"
 
     if [[ $1 == "unset" ]]; then


### PR DESCRIPTION
CML NUC has two USB host controllers. One of
them is Thunderbolt host controller. We want
to passthrough only the legacy USB host
controller. So, add an additional inverted grep
to not include the Thunderbolt USB controller.

Tracked-On: OAM-92008
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>