### PR TITLE
Corrected WIFI passthrough device input ID.

### DIFF
--- a/scripts/start_civ.sh
+++ b/scripts/start_civ.sh
@@ -346,7 +346,7 @@ function set_pt_wifi() {
         set_pt_pci_vfio $WIFI_PCI "unset"
     else
         set_pt_pci_vfio $WIFI_PCI
-        GUEST_WIFI_PT_DEV=" -device vfio-pci,host=${ETH_PCI#*:}"
+        GUEST_WIFI_PT_DEV=" -device vfio-pci,host=${WIFI_PCI#*:}"
     fi
 }
 


### PR DESCRIPTION
While doing wifi passthrough wrongly added ETH_PCI device id in
place of WIFI_PCI device id.

Tracked-On: OAM-92031
Signed-off-by: Raveendra Babu Chennakesavulu
                        <raveendra.babu.chennakesavulu@intel.com>