### PR TITLE
Limit read count of buf

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -93,7 +93,7 @@ int cleanup_child_proc(void)
 		return -1;
 	}
 
-	n = read(fd, buf, sizeof(buf));
+	n = read(fd, buf, sizeof(buf) - 1);
 	if (n == -1) {
 		fprintf(stderr, "read %s failed, errno=%d\n", str, errno);
 		close(fd);


### PR DESCRIPTION
Limit read count of but to (sizeof(buf) - 1) to avoid buffer
overflow in later strlen.

Tracked-On: OAM-92216
Signed-off-by: Qi, Yadong <yadong.qi@intel.com>