### PR TITLE
Added overflow-related CFlags

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -31,8 +31,8 @@ CFLAGS += -Wall -Wextra -Wbad-function-cast \
 	  -Wmissing-field-initializers -Wpointer-arith -Wcast-qual \
 	  -Wcast-align -Wwrite-strings \
 	  -fno-delete-null-pointer-checks -fstack-protector-strong \
-	  -D_FORTIFY_SOURCE=2
-
+	  -D_FORTIFY_SOURCE=2 \
+	  -fno-strict-overflow -fwrapv
 
 LDFLAGS = -lglib-2.0 -luuid -lmenu -lform -lncurses -ljson-c
 


### PR DESCRIPTION
Added compiler flags that handles overflow.

Flags added:
    
            -fno-strict-overflow: tells the compiler NOT to assume that signed overflow does not occur.
            -fwrapv: tells the compiler that signed overflow always wraps.
    
Tracked-On: OAM-92297
Signed-off-by: Qiaosong Zhou <qiaosong.zhou@intel.com>