### PR TITLE
Host setup failing if there is no patch in folder

### DIFF
--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -47,7 +47,7 @@ function ubu_install_qemu_gvt(){
         for i in $CIV_GOP_DIR/qemu/*.patch; do patch -p1 < $i; done
     fi
 
-    if [ -d $CIV_VERTICAl_DIR ]; then
+    if [ -f $CIV_VERTICAl_DIR/qemu/*.patch ]; then
 	for i in $CIV_VERTICAl_DIR/qemu/*.patch; do
         echo "applying qemu patch $i";
         patch -p1 < $i; done
@@ -83,7 +83,7 @@ function ubu_build_ovmf_gvt(){
         cp $CIV_GOP_DIR/ovmf/Vbt.bin OvmfPkg/Vbt/Vbt.bin
     fi
 
-    if [ -d $CIV_VERTICAl_DIR ]; then
+    if [ -f $CIV_VERTICAl_DIR/ovmf/*.patch ]; then
         for i in $CIV_VERTICAl_DIR/ovmf/*.patch; do
                 echo "applying ovmf patch $i";
                 patch -p1 < $i; done


### PR DESCRIPTION
Apply vertical host Qemu/OVMF patches to host setup failing if there is no patch in folder

Tracked-On: OAM-92655
Signed-off-by: amalendu.prasad.das <aprasadd@inlubt0251.iind.intel.com>