### PR TITLE
Launch QEMU with eval $EXE_CMD instead of $EXE_CMD

### DIFF
--- a/scripts/start_civ.sh
+++ b/scripts/start_civ.sh
@@ -597,7 +597,7 @@ function launch_guest() {
     "
 
     echo $EXE_CMD
-    $EXE_CMD
+    eval $EXE_CMD
 }
 
 function show_help() {


### PR DESCRIPTION
The QEMU parameters could have extra quotes and spaces, without using
eval the string could be considered a invalid command. So using eval to
pass the entire $EXE_CMD to the interpreter.

Tracked-On: OAM-92800
Signed-off-by: Colin Xu <colin.xu@intel.com>