### PR TITLE
Change in start_civ script for guest_pm_control call

### DIFF
--- a/scripts/start_civ.sh
+++ b/scripts/start_civ.sh
@@ -528,7 +528,6 @@ function set_guest_pm() {
         local guest_pm_qmp_sock=$WORK_DIR/qmp-pm-sock
         $guest_pm_ctrl_daemon $guest_pm_qmp_sock &
         GUEST_PM_CTRL="-qmp unix:$guest_pm_qmp_sock,server,nowait -no-reboot"
-        $guest_pm_ctrl_daemon "$guest_pm_ctrl_pipe" &
     fi
 }
 


### PR DESCRIPTION
guest-pm-control script is getting called twice
in start_civ script. The second call keeps it in a
continuous loop resulting in increase in CPU temp.

Tracked-On: OAM-92966
Signed-off-by: Shwetha B <shwetha.b@intel.com>