### PR TITLE
scripts: Increase USB port numbers

### DIFF
--- a/scripts/start_civ.sh
+++ b/scripts/start_civ.sh
@@ -52,7 +52,7 @@ GUEST_STATIC_OPTION="\
  -enable-kvm \
  -k en-us \
  -cpu host \
- -device qemu-xhci,id=xhci \
+ -device qemu-xhci,id=xhci,p2=8,p3=8 \
  -usb \
  -device usb-kbd \
  -device usb-mouse \


### PR DESCRIPTION
Qemu only has 4 ports that support high speed.
So, when a fifth device is added, it creates an
emulated hub to attach the device. The emulated
hub supports only USB 1.1 and so we get 'speed
mismatch' error whenever a high speed device like
a camera is connected as fifth device. So, change
the default configuration to support more USB2.0
(high speed) and USB 3.0 (superspeed) ports.

Tracked-On: OAM-92919
Signed-off-by: saranya <saranya.gopal@intel.com>