### PR TITLE
PCI device passthrough option for vm-manager

### DIFF
--- a/src/guest/guest.c
+++ b/src/guest/guest.c
@@ -31,6 +31,7 @@ keyfile_group_t g_group[] = {
 	{ "vtpm",     { "bin_path", "data_dir", NULL } },
 	{ "rpmb",     { "bin_path", "data_dir", NULL } },
 	{ "extra",    { "cmd", NULL } },
+	{ "passthrough", { "passthrough_pci", NULL}},
 };
 
 int load_form_data(char *name)
@@ -120,6 +121,10 @@ int load_form_data(char *name)
 	g = &g_group[GROUP_EXTRA];
 	val = g_key_file_get_string(in, g->name, g->key[EXTRA_CMD], NULL);
 	set_field_data(FORM_INDEX_EXTRA_CMD, val);
+
+	g = &g_group[GROUP_PCI_PT];
+	val = g_key_file_get_string(in, g->name, g->key[PCI_PT], NULL);
+	set_field_data(FORM_INDEX_PCI_PT, val);
 
 	return 0;
 }
@@ -281,6 +286,10 @@ int generate_keyfile(void)
 
 	get_field_data(FORM_INDEX_EXTRA_CMD, temp, sizeof(temp) - 1);
 	g_key_file_set_string(out, g_group[GROUP_EXTRA].name, g_group[GROUP_EXTRA].key[EXTRA_CMD], temp);
+	
+	get_field_data(FORM_INDEX_PCI_PT, temp, sizeof(temp) - 1);
+
+	g_key_file_set_string(out, g_group[GROUP_PCI_PT].name, g_group[GROUP_PCI_PT].key[PCI_PT], temp);
 
 	g_key_file_save_to_file(out, file_path, NULL);
 	ret = 0;

--- a/src/guest/rpmb.c
+++ b/src/guest/rpmb.c
@@ -111,3 +111,15 @@ int run_rpmb_daemon(void)
 	snprintf(cmd, 1024, "--dev %s/%s --sock %s/%s", rpmb.data_dir, RPMB_DATA, rpmb.data_dir, RPMB_SOCK);
 	return execute_cmd(rpmb.bin, cmd, strlen(cmd), 1);
 }
+
+void cleanup_rpmb(void) {
+	char path[1024] = { 0 };
+	struct stat st;
+
+	memset(path, 0, sizeof(path));
+	snprintf(path, 1024, "%s/%s", rpmb.data_dir, RPMB_SOCK);
+
+	if (stat(path, &st) == 0) {
+		remove(path);
+	}
+}

--- a/src/guest/tui.c
+++ b/src/guest/tui.c
@@ -295,13 +295,13 @@ int set_field_data(form_index_t index, const char *in)
 		break;
 	case FORM_INDEX_VGPU_GVTG_VER:
 		set_opts_buffer(g_form_field_data[index].input.f, in);
-		if (strcmp(in, GVTG_OPTS_V5_1_STR))
+		if (strcmp(in, GVTG_OPTS_V5_1_STR) == 0)
 			gvtg_sub_opts.pick_index = GVTG_OPTS_V5_1;
-		else if (strcmp(in, GVTG_OPTS_V5_2_STR))
+		else if (strcmp(in, GVTG_OPTS_V5_2_STR) == 0)
 			gvtg_sub_opts.pick_index = GVTG_OPTS_V5_2;
-		else if (strcmp(in, GVTG_OPTS_V5_4_STR))
+		else if (strcmp(in, GVTG_OPTS_V5_4_STR) == 0)
 			gvtg_sub_opts.pick_index = GVTG_OPTS_V5_4;
-		else if (strcmp(in, GVTG_OPTS_V5_8_STR))
+		else if (strcmp(in, GVTG_OPTS_V5_8_STR) == 0)
 			gvtg_sub_opts.pick_index = GVTG_OPTS_V5_8;
 		break;
 	case FORM_INDEX_PCI_PT: ;

--- a/src/include/guest/guest.h
+++ b/src/include/guest/guest.h
@@ -51,6 +51,7 @@ typedef enum {
 	FORM_INDEX_VTPM_DATA_DIR,
 	FORM_INDEX_RPMB_BIN_PATH,
 	FORM_INDEX_RPMB_DATA_DIR,
+	FORM_INDEX_PCI_PT,
 	FORM_INDEX_EXTRA_CMD,
 	FORM_NUM
 } form_index_t;
@@ -87,6 +88,8 @@ enum {
 #define GVTG_OPTS_V5_4_STR "i915-GVTg_V5_4"
 #define GVTG_OPTS_V5_8_STR "i915-GVTg_V5_8"
 
+#define PT_MAX 64		// Maximum number of passthrough devices
+
 enum {
 	FIELD_TYPE_NORMAL = 0,
 	FIELD_TYPE_ALNUM,
@@ -110,6 +113,7 @@ enum {
 	GROUP_VTPM,
 	GROUP_RPMB,
 	GROUP_EXTRA,
+	GROUP_PCI_PT,
 	GROUP_NUM
 };
 
@@ -154,10 +158,13 @@ enum {
 
 	/* Sub key of group vgpu */
 	EXTRA_CMD = 0,
+
+	/* Sub key of group pci passthrough */
+	PCI_PT = 0,
 };
 
 void show_msg(const char *msg);
-int set_field_data(form_index_t i, char *str);
+int set_field_data(form_index_t i, const char *str);
 int get_field_data(form_index_t i, char *str, size_t len);
 int generate_keyfile(void);
 int load_form_data(char *name);

--- a/src/include/guest/rpmb.h
+++ b/src/include/guest/rpmb.h
@@ -14,5 +14,6 @@
 int set_rpmb_bin_path(const char *bin_path);
 int set_rpmb_data_dir(const char *data_dir);
 int run_rpmb_daemon(void);
+void cleanup_rpmb(void);
 
 #endif /* __RPMB_H__ */

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -23,5 +23,6 @@ typedef struct
 int write_to_file(const char *path, const char *buffer);
 int find_pci(const char * name, int n, char *res[]);
 int find_ProgIf(char *pci_device, char * res); 
+int load_kernel_module(const char *module);
 
 #endif /* __UTILS_H__ */

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -8,8 +8,20 @@
 #ifndef __UTILS_H__
 #define __UTILS_H__
 
+
 int execute_cmd(const char *cmd, const char *arg, size_t arg_len, int daemonize);
 
 int cleanup_child_proc(void);
+
+typedef struct
+{
+	FILE *read_fd;
+	FILE *write_fd;
+	pid_t child_pid;
+} SPC_PIPE;
+
+int write_to_file(const char *path, const char *buffer);
+int find_pci(const char * name, int n, char *res[]);
+int find_ProgIf(char *pci_device, char * res); 
 
 #endif /* __UTILS_H__ */

--- a/src/include/vm_manager.h
+++ b/src/include/vm_manager.h
@@ -28,4 +28,6 @@ void list_guests(void);
 int stop_guest(char *name);
 int delete_guest(char *name);
 
+void set_cleanup();
+
 #endif /* __VM_MANAGER_H__*/

--- a/src/utils.c
+++ b/src/utils.c
@@ -119,3 +119,335 @@ int cleanup_child_proc(void)
 	}
 	return 0;
 }
+
+/* Code adapted from O'Reilly's "Secure Programming Cookbook for C and C++" */
+
+static int orig_ngroups = -1;
+static gid_t orig_gid = -1;
+static uid_t orig_uid = -1;
+static gid_t orig_groups[NGROUPS_MAX];
+
+static void spc_drop_privileges(int permanent)
+{
+	gid_t newgid = getgid(), oldgid = getegid();
+	uid_t newuid = getuid(), olduid = geteuid();
+
+	if (!permanent)
+	{
+		/* Save information about the privileges that are being dropped so that they
+ 		* can be restored later.
+ 		*/
+		orig_gid = oldgid;
+		orig_uid = olduid;
+		orig_ngroups = getgroups(NGROUPS_MAX, orig_groups);
+	}
+
+	/* If root privileges are to be dropped, be sure to pare down the ancillary
+	* groups for the process before doing anything else because the setgroups(  )
+	* system call requires root privileges.  Drop ancillary groups regardless of
+	* whether privileges are being dropped temporarily or permanently.
+	*/
+	if (!olduid)
+		setgroups(1, &newgid);
+
+	if (newgid != oldgid)
+	{
+#if !defined(linux)
+		setegid(newgid);
+		if (permanent && setgid(newgid) == -1)
+			abort();
+#else
+		if (setregid((permanent ? newgid : -1), newgid) == -1)
+			abort();
+#endif
+	}
+
+	if (newuid != olduid)
+	{
+#if !defined(linux)
+		seteuid(newuid);
+		if (permanent && setuid(newuid) == -1)
+			abort();
+#else
+		if (setreuid((permanent ? newuid : -1), newuid) == -1)
+			abort();
+#endif
+	}
+
+	/* verify that the changes were successful */
+	if (permanent)
+	{
+		if (newgid != oldgid && (setegid(oldgid) != -1 || getegid() != newgid))
+			abort();
+		if (newuid != olduid && (seteuid(olduid) != -1 || geteuid() != newuid))
+			abort();
+	}
+	else
+	{
+		if (newgid != oldgid && getegid() != newgid)
+			abort();
+		if (newuid != olduid && geteuid() != newuid)
+			abort();
+	}
+}
+
+static pid_t spc_fork(void)
+{
+	pid_t childpid;
+
+	if ((childpid = fork()) == -1)
+		return -1;
+
+	/* Reseed PRNGs in both the parent and the child */
+	/* See Chapter 11 for examples */
+
+	/* If this is the parent process, there's nothing more to do */
+	if (childpid != 0)
+		return childpid;
+
+	/* This is the child process */
+	spc_drop_privileges(1); /* Permanently drop privileges.  See Recipe 1.3 */
+
+	return 0;
+}
+
+static SPC_PIPE *spc_popen(const char *path, char *const argv[], char *const envp[])
+{
+	int stdin_pipe[2], stdout_pipe[2];
+	SPC_PIPE *p;
+
+	if (!(p = (SPC_PIPE *)malloc(sizeof(SPC_PIPE))))
+		return 0;
+	p->read_fd = p->write_fd = 0;
+	p->child_pid = -1;
+
+	if (pipe(stdin_pipe) == -1)
+	{
+		free(p);
+		return 0;
+	}
+	if (pipe(stdout_pipe) == -1)
+	{
+		close(stdin_pipe[1]);
+		close(stdin_pipe[0]);
+		free(p);
+		return 0;
+	}
+
+	if (!(p->read_fd = fdopen(stdout_pipe[0], "r")))
+	{
+		close(stdout_pipe[1]);
+		close(stdout_pipe[0]);
+		close(stdin_pipe[1]);
+		close(stdin_pipe[0]);
+		free(p);
+		return 0;
+	}
+	if (!(p->write_fd = fdopen(stdin_pipe[1], "w")))
+	{
+		fclose(p->read_fd);
+		close(stdout_pipe[1]);
+		close(stdin_pipe[1]);
+		close(stdin_pipe[0]);
+		free(p);
+		return 0;
+	}
+
+	if ((p->child_pid = spc_fork()) == -1)
+	{
+		fclose(p->write_fd);
+		fclose(p->read_fd);
+		close(stdout_pipe[1]);
+		close(stdin_pipe[0]);
+		free(p);
+		return 0;
+	}
+
+	if (!p->child_pid)
+	{
+		/* this is the child process */
+		close(stdout_pipe[0]);
+		close(stdin_pipe[1]);
+		if (stdin_pipe[0] != 0)
+		{
+			dup2(stdin_pipe[0], 0);
+			close(stdin_pipe[0]);
+		}
+		if (stdout_pipe[1] != 1)
+		{
+			dup2(stdout_pipe[1], 1);
+			close(stdout_pipe[1]);
+		}
+		execve(path, argv, envp);
+		exit(127);
+	}
+
+	close(stdout_pipe[1]);
+	close(stdin_pipe[0]);
+	return p;
+}
+
+static int spc_pclose(SPC_PIPE *p)
+{
+	int status;
+	pid_t pid;
+
+	if (p->child_pid != -1)
+	{
+		do
+		{
+			pid = waitpid(p->child_pid, &status, 0);
+		} while (pid == -1 && errno == EINTR);
+	}
+	if (p->read_fd)
+		fclose(p->read_fd);
+	if (p->write_fd)
+		fclose(p->write_fd);
+	free(p);
+	if (pid != -1 && WIFEXITED(status))
+		return WEXITSTATUS(status);
+	else
+		return (pid == -1 ? -1 : 0);
+}
+
+int write_to_file(const char *path, const char *buffer)
+{
+	int n, fd;
+
+	fd = open(path, O_WRONLY);
+	if (fd == -1)
+	{
+		fprintf(stderr, "open %s failed, errno=%d, %s\n", path, errno, strerror(errno));
+		return -1;
+	}
+
+	n = strlen(buffer);
+	if (write(fd, buffer, n) != n)
+	{
+		fprintf(stderr, "write %s failed, errno=%d, %s\n", path, errno, strerror(errno));
+		close(fd);
+		return -1;
+	}
+
+	close(fd);
+
+	return 0;
+}
+
+static void print_regerror(int errcode, size_t length, regex_t *compiled)
+{
+	char buffer[length];
+	(void)regerror(errcode, compiled, buffer, length);
+	fprintf(stderr, "Regex match failed: %s\n", buffer);
+}
+
+int find_pci(const char *name, int n, char *res[])
+{
+	/* returns number of pci devices found, -1 if error. */
+	char buffer[4096];
+	char search_key[64];
+	regex_t regex;
+	int result;
+	snprintf(search_key, 64, "....:..:..\\..( %s)", name);
+	result = regcomp(&regex, search_key, REG_EXTENDED);
+	if (result)
+	{
+		if (result == REG_ESPACE)
+			fprintf(stderr, "%s\n", strerror(ENOMEM));
+		else
+			fputs("Syntax error in the regular expression passed as first argument\n", stderr);
+		return -1;
+	}
+
+	regmatch_t matches[1];
+	int count_res = 0;
+	char *options[] = {"lspci", "-D", (char *)0};
+	char *env[] = {(char *)0};
+	SPC_PIPE *pipe_lspci = spc_popen("/usr/bin/lspci", options, env);
+	if (pipe_lspci != 0)
+	{
+		while (fgets(buffer, sizeof(buffer), pipe_lspci->read_fd) != NULL)
+		{
+			result = regexec(&regex, buffer, 1, matches, 0);
+
+			if (!result)
+			{
+				strncpy(res[count_res], buffer + matches[0].rm_so, 12);
+				res[count_res++][12] = '\0';
+
+				if (count_res >= n)
+					break;
+			}
+			else if (result == REG_NOMATCH)
+			{
+				// No match on current line
+			}
+			else
+			{
+				size_t length = regerror(result, &regex, NULL, 0);
+				print_regerror(result, length, &regex);
+			}
+		}
+	}
+	else
+	{
+		fprintf(stderr, "Failed to create spc pipe for lspci.");
+		return -1;
+	}
+	spc_pclose(pipe_lspci);
+	return count_res;
+}
+
+int find_ProgIf(char *pci_device, char *res)
+{
+	/* returns 0 if ProgIf is found, -1 if not */
+	char buffer[4096];
+	char search_key[64] = "ProgIf";
+	regex_t regex;
+	int result;
+
+	result = regcomp(&regex, search_key, REG_EXTENDED);
+	if (result)
+	{
+		if (result == REG_ESPACE)
+			fprintf(stderr, "%s\n", strerror(ENOMEM));
+		else
+			fputs("Syntax error in the regular expression passed as first argument\n", stderr);
+		return -1;
+	}
+
+	regmatch_t matches[1];
+	int count_res = 0;
+	char *options[] = {"lspci", "-vmms", pci_device, (char *)0};
+	char *env[] = {(char *)0};
+	SPC_PIPE *pipe_lspci = spc_popen("/usr/bin/lspci", options, env);
+	if (pipe_lspci != 0)
+	{
+		while (fgets(buffer, sizeof(buffer), pipe_lspci->read_fd) != NULL)
+		{
+			result = regexec(&regex, buffer, 1, matches, 0);
+			if (!result)
+			{
+				strncpy(res, buffer + matches[0].rm_so + 8, 3);
+				res[2] = '\0';
+				count_res = 1;
+				break;
+			}
+			else if (result == REG_NOMATCH)
+			{
+				// No match on current line
+			}
+			else
+			{
+				size_t length = regerror(result, &regex, NULL, 0);
+				print_regerror(result, length, &regex);
+			}
+		}
+	}
+	else
+	{
+		fprintf(stderr, "Failed to create spc pipe for lspci.");
+		return -1;
+	}
+	return count_res ? 0 : -1;
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -14,7 +14,15 @@
 #include <errno.h>
 #include <sys/wait.h>
 #include <sys/types.h>
+#include <sys/param.h>
 #include "vm_manager.h"
+#include "utils.h"
+#include <string.h>
+#include <paths.h>
+#include <regex.h>
+
+#define PCI_STR_SIZE 16
+
 
 
 int execute_cmd(const char *cmd, const char *arg, size_t arg_len, int daemonize)
@@ -107,8 +115,7 @@ int cleanup_child_proc(void)
 		ret = kill(child, SIGTERM);
 		if (ret != 0)
 			fprintf(stderr, "Failed to terminate sub-process: pid=%d, errno=%d\n", child, errno);
-		tok = strtok_r(buf," ", &ntok);
+		tok = strtok_r(NULL," ", &ntok);
 	}
-
 	return 0;
 }

--- a/src/vm_manager.c
+++ b/src/vm_manager.c
@@ -105,6 +105,8 @@ int main(int argc, char *argv[])
 	if (setup_work_dir() != 0)
 		return -1;
 
+	set_cleanup();
+
 	while (1) {
 		int option_index = 0;
 		static struct option long_options[] = {
@@ -140,6 +142,7 @@ int main(int argc, char *argv[])
 			break;
 		case 'b':
 			printf("start guest %s\n", optarg);
+			set_cleanup();
 			ret = start_guest(optarg);
 			break;
 		case 'q':

--- a/src/vm_manager.c
+++ b/src/vm_manager.c
@@ -144,6 +144,7 @@ int main(int argc, char *argv[])
 			printf("start guest %s\n", optarg);
 			set_cleanup();
 			ret = start_guest(optarg);
+			fprintf(stderr, "Exiting.");
 			break;
 		case 'q':
 			printf("stop guest %s\n", optarg);


### PR DESCRIPTION
First commit for pci-passthrough feature extension for vm-manager.
Added graphical feature to allow multiple selections in a suboption menu box.
Added secure vfio setup for passthrough devices.

Tracked-On: OAM-95606
Signed-off-by: Qiaosong Zhou <qiaosong.zhou@intel.com>