### PR TITLE
Support AAF and some fixing

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -14,6 +14,7 @@ SRCS += guest/tui.c
 SRCS += guest/qmp.c
 SRCS += guest/rpmb.c
 SRCS += guest/vtpm.c
+SRCS += guest/aaf.c
 
 INCLUDE = -I./include -I./include/guest
 

--- a/src/guest/aaf.c
+++ b/src/guest/aaf.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2021 Intel Corporation.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <err.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include "vm_manager.h"
+#include "guest.h"
+#include "utils.h"
+#include "aaf.h"
+
+#define AAF_FILE_NAME "mixins.spec"
+
+static const char *gpu_type[] = {
+	[AAF_GPU_TYPE_VIRTIO] = "gpu-type:virtio",
+	[AAF_GPU_TYPE_GVTG]   = "gpu-type:gvtg",
+	[AAF_GPU_TYPE_GVTD]   = "gpu-type:gvtd"
+};
+
+static const char *suspend_support[] = {
+	[AAF_SUSPEND_DISABLE] = "suspend:false",
+	[AAF_SUSPEND_ENABLE]  = "suspend:true"
+};
+
+static char *aaf_file = NULL;
+
+static const char *aaf_config_array[AAF_CONFIG_NUM] = { NULL };
+
+int set_aaf_path(const char *path)
+{
+	struct stat st;
+	size_t len;
+
+	if (!path) {
+		fprintf(stderr, "%s: Invalid input!\n", __func__);
+		return -1;
+	}
+
+	if (stat(path, &st) != 0) {
+		fprintf(stderr, "%s: cannot stat folder: %s, errno=%d\n", __func__, path, errno);
+		return -1;
+	}
+
+	len = strlen(path) + sizeof(AAF_FILE_NAME) + 1;
+
+	aaf_file = calloc(len, 1);
+	if (!aaf_file) {
+		fprintf(stderr, "%s: Failed to alloc memory!\n", __func__);
+		return -1;
+	}
+
+	snprintf(aaf_file, len, "%s/%s", path, AAF_FILE_NAME);
+
+	return 0;
+}
+
+int flush_aaf_config(void)
+{
+	FILE *fp;
+	int i;
+
+	if (!aaf_file)
+		return 0;
+
+	fp = fopen(aaf_file, "w");
+	if (!fp) {
+		fprintf(stderr, "%s: Failed to open AAF file:%s\n", __func__, aaf_file);
+		return -1;
+	}
+
+	for (i=0; i < AAF_CONFIG_NUM; i++) {
+		if (aaf_config_array[i])
+			fprintf(fp, "%s\n", aaf_config_array[i]);
+	}
+
+	fclose(fp);
+
+	return 0;
+}
+
+int set_aaf_option(aaf_config_opt_t opt, unsigned int sub)
+{
+	if (!aaf_file)
+		return 0;
+
+	switch (opt) {
+		case AAF_CONFIG_SUSPEND:
+			if (sub > AAF_SUSPEND_DISABLE)
+				return -1;
+			aaf_config_array[AAF_CONFIG_SUSPEND] = suspend_support[sub];
+			break;
+		case AAF_CONFIG_GPU_TYPE:
+			if (sub > AAF_GPU_TYPE_GVTD)
+				return -1;
+			aaf_config_array[AAF_CONFIG_GPU_TYPE] = gpu_type[sub];
+			break;
+		default:
+			fprintf(stderr, "%s: Invalid AAF config option!\n", __func__);
+			break;
+	}
+
+	return 0;
+}

--- a/src/guest/guest.c
+++ b/src/guest/guest.c
@@ -30,6 +30,7 @@ keyfile_group_t g_group[] = {
 	{ "graphics", { "type", "gvtg_version", "vgpu_uuid", NULL } },
 	{ "vtpm",     { "bin_path", "data_dir", NULL } },
 	{ "rpmb",     { "bin_path", "data_dir", NULL } },
+	{ "aaf",      { "path", NULL } },
 	{ "extra",    { "cmd", NULL } },
 	{ "passthrough", { "passthrough_pci", NULL}},
 };
@@ -117,6 +118,10 @@ int load_form_data(char *name)
 	set_field_data(FORM_INDEX_RPMB_BIN_PATH, val);
 	val = g_key_file_get_string(in, g->name, g->key[RPMB_DATA_DIR], NULL);
 	set_field_data(FORM_INDEX_RPMB_DATA_DIR, val);
+
+	g = &g_group[GROUP_AAF];
+	val = g_key_file_get_string(in, g->name, g->key[AAF_PATH], NULL);
+	set_field_data(FORM_INDEX_AAF_PATH, val);
 
 	g = &g_group[GROUP_EXTRA];
 	val = g_key_file_get_string(in, g->name, g->key[EXTRA_CMD], NULL);
@@ -283,6 +288,12 @@ int generate_keyfile(void)
 		goto exit;
 	}
 	g_key_file_set_string(out, g_group[GROUP_RPMB].name, g_group[GROUP_RPMB].key[RPMB_DATA_DIR], temp);
+
+	get_field_data(FORM_INDEX_AAF_PATH, temp, sizeof(temp) - 1);
+	if (0 == check_field(g_group[GROUP_AAF].key[AAF_PATH], temp)) {
+		g_key_file_set_string(out, g_group[GROUP_AAF].name, g_group[GROUP_AAF].key[AAF_PATH], temp);
+	}
+
 
 	get_field_data(FORM_INDEX_EXTRA_CMD, temp, sizeof(temp) - 1);
 	g_key_file_set_string(out, g_group[GROUP_EXTRA].name, g_group[GROUP_EXTRA].key[EXTRA_CMD], temp);

--- a/src/guest/guest.c
+++ b/src/guest/guest.c
@@ -406,7 +406,7 @@ int import_guest(char *in_path)
 				import_field(i, VGPU_GVTG_VER, in, out);
 			} else if (strcmp(val, VGPU_OPTS_GVTD_STR) == 0) {
 			} else if (strcmp(val, VGPU_OPTS_VIRTIO_STR) == 0) {
-			} else if (strcmp(val, VGPU_OPTS_SW_STR) == 0) {
+			} else if (strcmp(val, VGPU_OPTS_RAMFB_STR) == 0) {
 			} else {
 				g_warning("cannot find graphics sub-key\n");
 				return -1;

--- a/src/guest/guest.c
+++ b/src/guest/guest.c
@@ -30,7 +30,7 @@ keyfile_group_t g_group[] = {
 	{ "graphics", { "type", "gvtg_version", "vgpu_uuid", NULL } },
 	{ "vtpm",     { "bin_path", "data_dir", NULL } },
 	{ "rpmb",     { "bin_path", "data_dir", NULL } },
-	{ "aaf",      { "path", NULL } },
+	{ "aaf",      { "path", "support_suspend", NULL } },
 	{ "extra",    { "cmd", NULL } },
 	{ "passthrough", { "passthrough_pci", NULL}},
 };
@@ -122,6 +122,10 @@ int load_form_data(char *name)
 	g = &g_group[GROUP_AAF];
 	val = g_key_file_get_string(in, g->name, g->key[AAF_PATH], NULL);
 	set_field_data(FORM_INDEX_AAF_PATH, val);
+
+	g = &g_group[GROUP_AAF];
+	val = g_key_file_get_string(in, g->name, g->key[AAF_SUSPEND], NULL);
+	set_field_data(FORM_INDEX_AAF_SUSPEND, val);
 
 	g = &g_group[GROUP_EXTRA];
 	val = g_key_file_get_string(in, g->name, g->key[EXTRA_CMD], NULL);
@@ -292,6 +296,11 @@ int generate_keyfile(void)
 	get_field_data(FORM_INDEX_AAF_PATH, temp, sizeof(temp) - 1);
 	if (0 == check_field(g_group[GROUP_AAF].key[AAF_PATH], temp)) {
 		g_key_file_set_string(out, g_group[GROUP_AAF].name, g_group[GROUP_AAF].key[AAF_PATH], temp);
+	}
+
+	get_field_data(FORM_INDEX_AAF_SUSPEND, temp, sizeof(temp) - 1);
+	if (0 == check_field(g_group[GROUP_AAF].key[AAF_SUSPEND], temp)) {
+		g_key_file_set_string(out, g_group[GROUP_AAF].name, g_group[GROUP_AAF].key[AAF_SUSPEND], temp);
 	}
 
 

--- a/src/guest/qmp.c
+++ b/src/guest/qmp.c
@@ -71,7 +71,7 @@ int send_qmp_cmd(const char *path, const char *cmd, char **result)
 
 	memset((char *)&sock, 0, sizeof(sock));
 	sock.sun_family = AF_UNIX;
-	strncpy(sock.sun_path, path ,sizeof(sock.sun_path));
+	strncpy(sock.sun_path, path, sizeof(sock.sun_path) - 1);
 
 	sock_fd = socket(AF_UNIX, SOCK_STREAM, 0);
 	if (sock_fd < 0) {

--- a/src/guest/rpmb.c
+++ b/src/guest/rpmb.c
@@ -30,7 +30,6 @@ static struct _rpmb rpmb = { NULL, NULL };
 int set_rpmb_bin_path(const char *bin_path)
 {
 	struct stat st;
-	size_t len;
 
 	if (!bin_path) {
 		fprintf(stderr, "%s: Invalid input!\n", __func__);
@@ -42,15 +41,11 @@ int set_rpmb_bin_path(const char *bin_path)
 		return -1;
 	}
 
-	len = strlen(bin_path) + 1;
-
-	rpmb.bin = calloc(strlen(bin_path), len);
+	rpmb.bin = strndup(bin_path, MAX_PATH);
 	if (!rpmb.bin) {
-		fprintf(stderr, "Failed to alloc memory!\n");
+		fprintf(stderr, "Failed to duplicate rpmb bin path!\n");
 		return -1;
 	}
-
-	strncpy(rpmb.bin, bin_path,len);
 
 	return 0;
 }
@@ -58,7 +53,6 @@ int set_rpmb_bin_path(const char *bin_path)
 int set_rpmb_data_dir(const char *data_dir)
 {
 	struct stat st;
-	size_t len;
 
 	if (!data_dir)
 		return -1;
@@ -66,13 +60,11 @@ int set_rpmb_data_dir(const char *data_dir)
 	if (stat(data_dir, &st) != 0)
 		return -1;
 
-	len = strlen(data_dir) + 1;
-
-	rpmb.data_dir = malloc(strlen(data_dir));
-	if (!rpmb.data_dir)
+	rpmb.data_dir = strndup(data_dir, MAX_PATH);
+	if (!rpmb.data_dir) {
+		fprintf(stderr, "Failed to duplicate rpmb data dir!\n");
 		return -1;
-
-	strncpy(rpmb.data_dir, data_dir,len);
+	}
 
 	return 0;
 }

--- a/src/guest/start.c
+++ b/src/guest/start.c
@@ -39,7 +39,7 @@ static const char *fixed_cmd =
 	" -k en-us"
 	" -cpu host"
 	" -enable-kvm"
-	" -device qemu-xhci,id=xhci"
+	" -device qemu-xhci,id=xhci,p2=8,p3=8"
 	" -device usb-mouse"
 	" -device usb-kbd"
 	" -device intel-hda -device hda-duplex"

--- a/src/guest/start.c
+++ b/src/guest/start.c
@@ -568,7 +568,7 @@ int start_guest(char *name)
 		g_warning("cannot find key name from group disk\n");
 		return -1;
 	}
-	cx = snprintf(p, size, " -drive file=%s,if=none,id=disk1 -device virtio-blk-pci,drive=disk1,bootindex=1", val);
+	cx = snprintf(p, size, " -drive file=%s,if=none,id=disk1,discard=unmap,detect-zeroes=unmap -device virtio-blk-pci,drive=disk1,bootindex=1", val);
 	p += cx; size -= cx;
 
 	g = &g_group[GROUP_PCI_PT];

--- a/src/guest/start.c
+++ b/src/guest/start.c
@@ -462,6 +462,16 @@ int start_guest(char *name)
 		}
 		cx = snprintf(p, size, " -fsdev local,security_model=none,id=fsdev_aaf,path=%s -device virtio-9p-pci,fsdev=fsdev_aaf,mount_tag=aaf,addr=3", val);
 		p += cx; size -= cx;
+
+		val = g_key_file_get_string(gkf, g->name, g->key[AAF_SUSPEND], NULL);
+		if (val) {
+			if (0 == strcmp(val, SUSPEND_ENABLE_STR))
+				set_aaf_option(AAF_CONFIG_SUSPEND, AAF_SUSPEND_ENABLE);
+			else if (0 == strcmp(val, SUSPEND_DISABLE_STR))
+				set_aaf_option(AAF_CONFIG_SUSPEND, AAF_SUSPEND_DISABLE);
+			else
+				g_warning("Invalid setting of AAF Allow suspend option, it should be either true or false\n");
+		}
 	}
 
 	g = &g_group[GROUP_VGPU];

--- a/src/guest/start.c
+++ b/src/guest/start.c
@@ -514,8 +514,8 @@ int start_guest(char *name)
 		cx = snprintf(p, size, " -display gtk,gl=on -device virtio-gpu-pci");
 		p += cx; size -= cx;
 		set_aaf_option(AAF_CONFIG_GPU_TYPE, AAF_GPU_TYPE_VIRTIO);
-	} else if (strcmp(val, VGPU_OPTS_SW_STR) == 0) {
-		cx = snprintf(p, size, " -display gtk,gl=on -device qxl-vga,xres=480,yres=360");
+	} else if (strcmp(val, VGPU_OPTS_RAMFB_STR) == 0) {
+		cx = snprintf(p, size, " -display gtk,gl=on -device ramfb");
 		p += cx; size -= cx;
 	} else {
 		g_warning("Invalid Graphics config\n");

--- a/src/guest/tui.c
+++ b/src/guest/tui.c
@@ -122,6 +122,7 @@ static form_field_data_t g_form_field_data[FORM_NUM + 1] = {
 	{ { NULL, "rpmb bin        :" }, { NULL, FIELD_TYPE_NORMAL,  {                                 }, NULL               } },
 	{ { NULL, "rpmb data dir   :" }, { NULL, FIELD_TYPE_NORMAL,  {                                 }, NULL               } },
 	{ { NULL, "passthrough pci :" }, { NULL, FIELD_TYPE_NORMAL,  { 								   }, &passthrough_sub_opts	} },
+	{ { NULL, "aaf path        :" }, { NULL, FIELD_TYPE_NORMAL,  {                                 }, NULL               } },
 	{ { NULL, "extra cmd(qemu) :" }, { NULL, FIELD_TYPE_NORMAL,  {                                 }, NULL               } },
 	{ { NULL, NULL }, { NULL, -1, { }, NULL } }
 };

--- a/src/guest/tui.c
+++ b/src/guest/tui.c
@@ -93,13 +93,14 @@ static ITEM *items[MENU_NUM + 1];
 static FIELD *msg_field[2];
 static int form_start_row = 0;
 
+static int pt_selected[PT_MAX] = { 0 };
+static char pt_opts[PT_FIELD_LEN_MAX] = { 0 };
+
 static field_sub_opts_t firmware_sub_opts = 	{ 2, -1, NULL, { FIRM_OPTS_UNIFIED_STR,  FIRM_OPTS_SPLITED_STR } };
 static field_sub_opts_t graphics_sub_opts = 	{ 4, -1, NULL, { VGPU_OPTS_VIRTIO_STR, VGPU_OPTS_SW_STR, VGPU_OPTS_GVTG_STR, VGPU_OPTS_GVTD_STR } };
 static field_sub_opts_t gvtg_sub_opts =     	{ 4, -1, NULL, { GVTG_OPTS_V5_1_STR, GVTG_OPTS_V5_2_STR, GVTG_OPTS_V5_4_STR, GVTG_OPTS_V5_8_STR } };
-static int pt_selected[PT_MAX] = { 0 };
-static char pt_opts[PT_FIELD_LEN_MAX] = { 0 };
 static field_sub_opts_t passthrough_sub_opts = 	{ 5, -1, pt_selected, {NULL} };
-
+static field_sub_opts_t suspend_opts =          { 2, -1, NULL, { SUSPEND_ENABLE_STR, SUSPEND_DISABLE_STR } };
 
 static form_field_data_t g_form_field_data[FORM_NUM + 1] = {
 	{ { NULL, "name            :" }, { NULL, FIELD_TYPE_NORMAL,  {                                 }, NULL               } },
@@ -121,8 +122,9 @@ static form_field_data_t g_form_field_data[FORM_NUM + 1] = {
 	{ { NULL, "swtpm data dir  :" }, { NULL, FIELD_TYPE_NORMAL,  {                                 }, NULL               } },
 	{ { NULL, "rpmb bin        :" }, { NULL, FIELD_TYPE_NORMAL,  {                                 }, NULL               } },
 	{ { NULL, "rpmb data dir   :" }, { NULL, FIELD_TYPE_NORMAL,  {                                 }, NULL               } },
-	{ { NULL, "passthrough pci :" }, { NULL, FIELD_TYPE_NORMAL,  { 								   }, &passthrough_sub_opts	} },
+	{ { NULL, "passthrough pci :" }, { NULL, FIELD_TYPE_NORMAL,  {                                 }, &passthrough_sub_opts } },
 	{ { NULL, "aaf path        :" }, { NULL, FIELD_TYPE_NORMAL,  {                                 }, NULL               } },
+	{ { NULL, "suspend support :" }, { NULL, FIELD_TYPE_NORMAL,  {                                 }, &suspend_opts      } },
 	{ { NULL, "extra cmd(qemu) :" }, { NULL, FIELD_TYPE_NORMAL,  {                                 }, NULL               } },
 	{ { NULL, NULL }, { NULL, -1, { }, NULL } }
 };

--- a/src/guest/tui.c
+++ b/src/guest/tui.c
@@ -97,7 +97,7 @@ static int pt_selected[PT_MAX] = { 0 };
 static char pt_opts[PT_FIELD_LEN_MAX] = { 0 };
 
 static field_sub_opts_t firmware_sub_opts = 	{ 2, -1, NULL, { FIRM_OPTS_UNIFIED_STR,  FIRM_OPTS_SPLITED_STR } };
-static field_sub_opts_t graphics_sub_opts = 	{ 4, -1, NULL, { VGPU_OPTS_VIRTIO_STR, VGPU_OPTS_SW_STR, VGPU_OPTS_GVTG_STR, VGPU_OPTS_GVTD_STR } };
+static field_sub_opts_t graphics_sub_opts = 	{ 4, -1, NULL, { VGPU_OPTS_VIRTIO_STR, VGPU_OPTS_RAMFB_STR, VGPU_OPTS_GVTG_STR, VGPU_OPTS_GVTD_STR } };
 static field_sub_opts_t gvtg_sub_opts =     	{ 4, -1, NULL, { GVTG_OPTS_V5_1_STR, GVTG_OPTS_V5_2_STR, GVTG_OPTS_V5_4_STR, GVTG_OPTS_V5_8_STR } };
 static field_sub_opts_t passthrough_sub_opts = 	{ 5, -1, pt_selected, {NULL} };
 static field_sub_opts_t suspend_opts =          { 2, -1, NULL, { SUSPEND_ENABLE_STR, SUSPEND_DISABLE_STR } };
@@ -289,8 +289,8 @@ int set_field_data(form_index_t index, const char *in)
 			graphics_sub_opts.pick_index = VGPU_OPTS_GVTD;
 		} else if (strcmp(in, VGPU_OPTS_VIRTIO_STR) == 0) {
 			graphics_sub_opts.pick_index = VGPU_OPTS_VIRTIO;
-		} else if (strcmp(in, VGPU_OPTS_SW_STR) == 0) {
-			graphics_sub_opts.pick_index = VGPU_OPTS_SW;
+		} else if (strcmp(in, VGPU_OPTS_RAMFB_STR) == 0) {
+			graphics_sub_opts.pick_index = VGPU_OPTS_RAMFB;
 		} else {
 			fprintf(stderr, "Invalid virtual GPU type!\n");
 			return -1;

--- a/src/guest/vtpm.c
+++ b/src/guest/vtpm.c
@@ -30,7 +30,6 @@ static struct _vtpm vtpm = { NULL, NULL };
 int set_vtpm_bin_path(const char *bin_path)
 {
 	struct stat st;
-	size_t len;
 
 	if (!bin_path)
 		return -1;
@@ -38,13 +37,11 @@ int set_vtpm_bin_path(const char *bin_path)
 	if (stat(bin_path, &st) != 0)
 		return -1;
 
-	len = strlen(bin_path) + 1;
-
-	vtpm.bin = malloc(strlen(bin_path));
-	if (!vtpm.bin)
+	vtpm.bin = strndup(bin_path, MAX_PATH);
+	if (!vtpm.bin) {
+		fprintf(stderr, "Failed to duplicate swtpm bin dir!\n");
 		return -1;
-
-	strncpy(vtpm.bin, bin_path, len);
+	}
 
 	return 0;
 }
@@ -52,22 +49,18 @@ int set_vtpm_bin_path(const char *bin_path)
 int set_vtpm_data_dir(const char *data_dir)
 {
 	struct stat st;
-	size_t len;
 
-	printf("%s: %s\n", __func__, data_dir);
 	if (!data_dir)
 		return -1;
 
 	if (stat(data_dir, &st) != 0)
 		return -1;
 
-	len = strlen(data_dir) + 1;
-
-	vtpm.data_dir = malloc(strlen(data_dir));
-	if (!vtpm.data_dir)
+	vtpm.data_dir = strndup(data_dir, MAX_PATH);
+	if (!vtpm.data_dir) {
+		fprintf(stderr, "Failed to duplicate swtpm data dir!\n");
 		return -1;
-
-	strncpy(vtpm.data_dir,  data_dir, len);
+	}
 
 	return 0;
 }

--- a/src/include/guest/aaf.h
+++ b/src/include/guest/aaf.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020 Intel Corporation.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+#ifndef __AAF_H__
+#define __AAF_H__
+
+typedef enum {
+    AAF_CONFIG_GPU_TYPE = 0,
+    AAF_CONFIG_SUSPEND,
+    AAF_CONFIG_NUM
+} aaf_config_opt_t;
+
+enum {
+    AAF_SUSPEND_DISABLE = 0,
+    AAF_SUSPEND_ENABLE
+};
+
+enum {
+    AAF_GPU_TYPE_VIRTIO = 0,
+    AAF_GPU_TYPE_GVTG,
+    AAF_GPU_TYPE_GVTD
+};
+
+int set_aaf_path(const char *bin_path);
+int set_aaf_option(aaf_config_opt_t opt, unsigned int sub);
+int flush_aaf_config(void);
+
+#endif /* __AAF_H__ */

--- a/src/include/guest/guest.h
+++ b/src/include/guest/guest.h
@@ -68,13 +68,13 @@ enum {
 
 enum {
 	VGPU_OPTS_VIRTIO = 0,
-	VGPU_OPTS_SW,
+	VGPU_OPTS_RAMFB,
 	VGPU_OPTS_GVTG,
 	VGPU_OPTS_GVTD
 };
 
 #define VGPU_OPTS_VIRTIO_STR   "virtio"
-#define VGPU_OPTS_SW_STR       "swrender"
+#define VGPU_OPTS_RAMFB_STR    "ramfb"
 #define VGPU_OPTS_GVTG_STR     "GVT-g"
 #define VGPU_OPTS_GVTD_STR     "GVT-d"
 

--- a/src/include/guest/guest.h
+++ b/src/include/guest/guest.h
@@ -53,6 +53,7 @@ typedef enum {
 	FORM_INDEX_RPMB_DATA_DIR,
 	FORM_INDEX_PCI_PT,
 	FORM_INDEX_AAF_PATH,
+	FORM_INDEX_AAF_SUSPEND,
 	FORM_INDEX_EXTRA_CMD,
 	FORM_NUM
 } form_index_t;
@@ -90,6 +91,14 @@ enum {
 #define GVTG_OPTS_V5_8_STR "i915-GVTg_V5_8"
 
 #define PT_MAX 64		// Maximum number of passthrough devices
+
+enum {
+	SUSPEND_ENABLE = 0,
+	SUSPEND_DISABLE
+};
+
+#define SUSPEND_ENABLE_STR  "enable"
+#define SUSPEND_DISABLE_STR "disable"
 
 enum {
 	FIELD_TYPE_NORMAL = 0,
@@ -160,6 +169,7 @@ enum {
 
 	/* Sub key of group aaf */
 	AAF_PATH = 0,
+	AAF_SUSPEND,
 
 	/* Sub key of group vgpu */
 	EXTRA_CMD = 0,

--- a/src/include/guest/guest.h
+++ b/src/include/guest/guest.h
@@ -52,6 +52,7 @@ typedef enum {
 	FORM_INDEX_RPMB_BIN_PATH,
 	FORM_INDEX_RPMB_DATA_DIR,
 	FORM_INDEX_PCI_PT,
+	FORM_INDEX_AAF_PATH,
 	FORM_INDEX_EXTRA_CMD,
 	FORM_NUM
 } form_index_t;
@@ -112,6 +113,7 @@ enum {
 	GROUP_VGPU,
 	GROUP_VTPM,
 	GROUP_RPMB,
+	GROUP_AAF,
 	GROUP_EXTRA,
 	GROUP_PCI_PT,
 	GROUP_NUM
@@ -155,6 +157,9 @@ enum {
 	/* Sub key of group rpmb */
 	RPMB_BIN_PATH = 0,
 	RPMB_DATA_DIR,
+
+	/* Sub key of group aaf */
+	AAF_PATH = 0,
 
 	/* Sub key of group vgpu */
 	EXTRA_CMD = 0,


### PR DESCRIPTION
Fix some compile warnings …

Support AAF configuration …

Support configuration for suspend in AAF …

Change QXL display to RAMFB …

Increase default virtual usb port number …

Add BLKDISCARD and BLKDISCARDZEROES ioctl support

Tracked-On: OAM-95795
Signed-off-by: Yadong Qi <yadong.qi@intel.com>