### PR TITLE
scripts: enable intel-iommu.device-iotlb

### DIFF
--- a/scripts/start_civ.sh
+++ b/scripts/start_civ.sh
@@ -64,7 +64,7 @@ GUEST_STATIC_OPTION="\
  -chardev socket,id=charserial0,path=$WORK_DIR/kernel-console,server,nowait,logfile=$WORK_DIR/civ_serial.log \
  -serial chardev:charserial0 \
  -device virtio-blk-pci,drive=disk1,bootindex=1 \
- -device intel-iommu,device-iotlb=off,caching-mode=on \
+ -device intel-iommu,device-iotlb=on,caching-mode=on \
  -smbios type=2,serial=$GUEST_SMBIOS_SERIAL \
  -nodefaults"
 


### PR DESCRIPTION
Previously, intel-iommu.device-iotlb was turned off due to bugs in
QEMU. And we submitted patches[1][2] to fix the issue. Now we observed
that the patches have been merged into QEMU upstream and integrated
in release-4.2.0. So we will enable this feature for performance
improvement.

Releated patches:
[1]. https://gitlab.com/qemu-project/qemu/-/commit/e48929c787ed0ebed87877c97ac90c3a47ef7dda
[2]. https://gitlab.com/qemu-project/qemu/-/commit/ce586f3b8d2105657981a1a43107fe7c5374b280

Tracked-On: OAM-96184
Signed-off-by: Yadong Qi <yadong.qi@intel.com>