### PR TITLE
scripts: enable file share between guest and host

### DIFF
--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -175,6 +175,17 @@ function prepare_required_scripts(){
     chmod +x $CIV_WORK_DIR/scripts/batsys
 }
 
+function install_9p_module(){
+    echo "installing 9p kernel modules for file-sharing"
+    sudo modprobe 9pnet
+    sudo modprobe 9pnet_virtio
+    sudo modprobe 9p
+    FILE_SHARE_DIR=./share_folder
+    if [ ! -d "$FILE_SHARE_DIR" ]; then
+        mkdir ./share_folder
+    fi
+}
+
 function install_auto_start_service(){
     service_file=civ.service
     touch $service_file
@@ -318,7 +329,9 @@ function parse_arg() {
                 install_auto_start_service "$2" || return -1
                 shift
                 ;;
-
+            --file-share)
+                install_9p_module || return -1
+                ;;
             -?*)
                 echo "Error: Invalid option $1"
                 show_help

--- a/scripts/start_civ.sh
+++ b/scripts/start_civ.sh
@@ -66,6 +66,8 @@ GUEST_STATIC_OPTION="\
  -serial chardev:charserial0 \
  -device virtio-blk-pci,drive=disk1,bootindex=1 \
  -device intel-iommu,device-iotlb=on,caching-mode=on \
+ -fsdev local,security_model=none,id=fsdev0,path=./share_folder \
+ -device virtio-9p-pci,fsdev=fsdev0,mount_tag=hostshare \
  -smbios type=2,serial=$GUEST_SMBIOS_SERIAL \
  -nodefaults"
 


### PR DESCRIPTION
Enable 9p filesystem in host and setup the
environment to facilitate file sharing.

Tracked-On: OAM-97260
Signed-off-by: nitishat <nitisha.tomar@intel.com>