### PR TITLE
[Revert-me]: Workaround for BT issue in 5.4.121 kernel

### DIFF
--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -278,6 +278,8 @@ function ubu_update_bt_fw() {
         git checkout fa0efeff4894e36b9c3964376f2c99fae101d147
         cd -
         sudo cp linux-firmware/intel/ibt-19-0-4* /lib/firmware/intel
+        ln -s /lib/firmware/intel/ibt-19-0-4.sfi /lib/firmware/intel/ibt-19-16-0.sfi
+        ln -s /lib/firmware/intel/ibt-19-0-4.ddc /lib/firmware/intel/ibt-19-16-0.ddc
         hcitool cmd 3f 01 01 01 00 00 00 00 00 & > /dev/null
         sleep 5
         echo "BT FW in the host got updated"


### PR DESCRIPTION
With the 5.4.121 kernel BT is not working in host when
android guest is lauched with BT passsthrough and terminated.
In the new firmware download flow, even when firmware is in
operational mode, the firmware version and revision are
checked to see if the firmware in the device is latest.
Because the firmware returns wrong device information, driver
tries to load incorrect firmware file, resulting in failure
in the BT initialisation

Fix: Soft links are created so that ibt-19-16-0* pointing to
ibt-19-0-4*

Patch will be reverted once the firmware changes are available

Tracked-On: OAM-97192
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>