### PR TITLE
enable intel-iommu.device-iotlb

### DIFF
--- a/src/guest/start.c
+++ b/src/guest/start.c
@@ -46,7 +46,7 @@ static const char *fixed_cmd =
 	" -device intel-hda -device hda-duplex"
 	" -audiodev id=android_spk,timer-period=5000,driver=pa"
 	" -device e1000,netdev=net0"
-	" -device intel-iommu,device-iotlb=off,caching-mode=on"
+	" -device intel-iommu,device-iotlb=on,caching-mode=on"
 	" -nodefaults ";
 
 /* Used to keep track of pcis that are passed through */


### PR DESCRIPTION
Previously, intel-iommu.device-iotlb was turned off due to bugs in
QEMU. And we submitted patches[1][2] to fix the issue. Now we observed
that the patches have been merged into QEMU upstream and integrated
in release-4.2.0. So we will enable this feature for performance
improvement.

Releated patches:
[1]. https://gitlab.com/qemu-project/qemu/-/commit/e48929c787ed0ebed87877c97ac90c3a47ef7dda
[2]. https://gitlab.com/qemu-project/qemu/-/commit/ce586f3b8d2105657981a1a43107fe7c5374b280

Tracked-On: OAM-98093
Signed-off-by: Yadong Qi <yadong.qi@linux.intel.com>