### PR TITLE
Fix bt fw update issue

### DIFF
--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -303,7 +303,6 @@ function ubu_update_bt_fw() {
                 sudo rfkill unblock bluetooth
             fi
         fi
-        hciconfig hci0 up
         if [ -d "linux-firmware" ] ; then
             rm -rf linux-firmware
         fi
@@ -321,6 +320,7 @@ function ubu_update_bt_fw() {
         hcitool cmd 3f 01 01 01 00 00 00 00 00 > /dev/null 2>&1 &
         sleep 5
         echo "BT FW in the host got updated"
+        hciconfig hci0 up
         reboot_required=1
     else
         usb_devices="/sys/kernel/debug/usb/devices"

--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -297,7 +297,6 @@ function ubu_update_bt_fw() {
         kill $qemu_pid > /dev/null
         sleep 5
     fi
-
     if [ "$(hciconfig)" != "" ]; then
         if [ "$(hciconfig | grep "UP")" == "" ]; then
             if [ "$(rfkill list bluetooth | grep "Soft blocked: no" )" == "" ]; then
@@ -310,11 +309,13 @@ function ubu_update_bt_fw() {
         fi
         git clone https://kernel.googlesource.com/pub/scm/linux/kernel/git/firmware/linux-firmware
         cd linux-firmware
-        # Checkout to specific firmware version 22.50.0.4 as guest also uses this version. Latest
+        # Checkout to specific commit as guest also uses this version. Latest
         # is not taken as firmware update process in the guest is manual
-        git checkout fa0efeff4894e36b9c3964376f2c99fae101d147
+        git checkout b377ccf4f1ba7416b08c7f1170c3e28a460ac29e
         cd -
         sudo cp linux-firmware/intel/ibt-19-0-4* /lib/firmware/intel
+        sudo cp linux-firmware/intel/ibt-18-16-1* /lib/firmware/intel
+        sudo cp linux-firmware/intel/ibt-0040-0041* /lib/firmware/intel
         ln -sf /lib/firmware/intel/ibt-19-0-4.sfi /lib/firmware/intel/ibt-19-16-0.sfi
         ln -sf /lib/firmware/intel/ibt-19-0-4.ddc /lib/firmware/intel/ibt-19-16-0.ddc
         hcitool cmd 3f 01 01 01 00 00 00 00 00 > /dev/null 2>&1 &


### PR DESCRIPTION
In certain case bt fw update will fail if "hciconfig hci0 up" command fails in the script. Always call "hciconfig hci0 up" after
fw update completes.
