### PR TITLE
Fix bt fw update issue

### DIFF
--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -303,7 +303,6 @@ function ubu_update_bt_fw() {
                 sudo rfkill unblock bluetooth
             fi
         fi
-        hciconfig hci0 up
         if [ -d "linux-firmware" ] ; then
             rm -rf linux-firmware
         fi
@@ -321,6 +320,7 @@ function ubu_update_bt_fw() {
         hcitool cmd 3f 01 01 01 00 00 00 00 00 > /dev/null 2>&1 &
         sleep 5
         echo "BT FW in the host got updated"
+        hciconfig hci0 up
         reboot_required=1
     else
         usb_devices="/sys/kernel/debug/usb/devices"


### PR DESCRIPTION
In certain case bt fw update will fail if "hciconfig hci0 up"
command fails in the script. Always call "hciconfig hci0 up" after
fw update completes.

Tracked-on: OAM-100122
Signed-off-by: Bharat B Panda <bharat.b.panda@intel.com>