### PR TITLE
Merge patches related to RTC and Alarm Virtualization

### DIFF
--- a/scripts/guest_time_keeping.sh
+++ b/scripts/guest_time_keeping.sh
@@ -11,6 +11,9 @@
 # QMP RTC_EVENT JSON Sample:
 # {"timestamp": {"seconds": 1585714481, "microseconds": 85991}, "event": "RTC_CHANGE", "data": {"offset": -1}}
 
+# QMP RTC_ALARM JSON Sample:
+# {"timestamp": {"seconds": 1593413313, "microseconds": 568267}, "event": "RTC_ALARM", "data": {"expire": 1593499713567502000}}
+
 # If guest time is set earlier than the image build time, the guest time will become the image build time after
 # reboot
 
@@ -18,6 +21,7 @@ set -eE
 
 #------------------------------------ Global Variables -----------------------------------------
 QMP_PIPE=$1
+RTC_MONITOR=$2
 
 #------------------------------------     Functions    -----------------------------------------
 function send_qmp_cmd() {
@@ -66,63 +70,6 @@ function connect_qmp_pipe() {
     fi
 }
 
-function update_host_date() {
-    local offset=$1
-
-    [[ $offset -eq 0 ]] && return
-
-    echo "Guest time changed"
-    local old_time=$(date)
-    date -s "$offset seconds"
-    local updated_time=$(date)
-
-    if [ $? = "0" ]; then
-        hwclock --systohc
-        echo "Host time is set from \"$old_time\" to \"$updated_time\""
-    else
-        echo "Fail to set host time"
-    fi
-}
-
-function monitor_guest_rtc_change() {
-    if [[ -z $1 ]]; then
-        echo "E: Empty QMP pipe"
-        return -1
-    fi
-
-    local qmp_pipe_out=$1".out"
-    if [[ ! -p $qmp_pipe_out ]]; then
-        echo "E: Not named pipe: $qmp_pipe_out"
-        return -1
-    fi
-
-    local pout
-    while true; do
-        if [ ! `pgrep qemu-system` ]; then
-            echo "E: Guest is not alive!"
-            return -1
-        fi
-
-        read pout < $qmp_pipe_out
-        local event=$(jq -r .event <<< "$pout")
-
-        case $event in
-            RTC_CHANGE)
-                local offset=$(jq -r .data.offset <<< "$pout")
-                update_host_date "$offset"
-                ;;
-            SHUTDOWN)
-                return
-                ;;
-            *)
-                continue
-                ;;
-        esac
-
-        sleep 1
-    done
-}
-
 function create_pipe() {
     [[ -z $1 ]] && return
     [[ -p $1".in" ]] || mkfifo $1".in"
@@ -132,4 +79,4 @@ function create_pipe() {
 #------------------------------------     Main process    -----------------------------------------
 create_pipe "$QMP_PIPE" || exit -1
 connect_qmp_pipe "$QMP_PIPE" || exit -1
-monitor_guest_rtc_change "$QMP_PIPE"
+exec "$RTC_MONITOR" "$QMP_PIPE.in" "$QMP_PIPE.out"

--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -47,6 +47,8 @@ function ubu_install_qemu_gvt(){
     patch -p1 < $CIV_WORK_DIR/patches/qemu/Disable-EDID-auto-generation-in-QEMU.patch
     patch -p1 < $CIV_WORK_DIR/patches/qemu/0001-Revert-Revert-vfio-pci-quirks.c-Disable-stolen-memor.patch
     patch -p1 < $CIV_WORK_DIR/patches/qemu/0002-qemu-change-fence-poll-time-by-current-workload.patch
+    patch -p1 < $CIV_WORK_DIR/patches/qemu/0003-mc146818rtc-add-RTC_ALARM-QMP-event.patch
+    patch -p1 < $CIV_WORK_DIR/patches/qemu/0004-mc146818rtc-add-rtc-refresh-timer-QMP-command.patch
     if [ -d $CIV_GOP_DIR ]; then
         for i in $CIV_GOP_DIR/qemu/*.patch; do patch -p1 < $i; done
     fi
@@ -173,6 +175,8 @@ function prepare_required_scripts(){
     chmod +x $CIV_WORK_DIR/scripts/findall.py
     chmod +x $CIV_WORK_DIR/scripts/thermsys
     chmod +x $CIV_WORK_DIR/scripts/batsys
+    sudo chown root $CIV_WORK_DIR/scripts/guest_rtc_monitor
+    sudo chmod u+s $CIV_WORK_DIR/scripts/guest_rtc_monitor
 }
 
 function install_auto_start_service(){


### PR DESCRIPTION
Replace guest_time_keeping.sh with QMP client utility
Add '--external-wakeup-mode' option to use host rtc

Now guest_time_keeping.sh just creates the QMP channel and passes
control to guest_rtc_monitor utility.

Add the above to patching of Qemu in setup_host

Tracked-On: OAM-100320
Signed-off-by: Zhuocheng Ding <zhuocheng.ding@intel.com>
Signed-off-by: Zhuo Peng <zhuo.peng@intel.com>
Signed-off-by: Shwetha B <shwetha.b@intel.com>