### PR TITLE
switch to use swiftshader for CiV software rendering

### DIFF
--- a/src/guest/guest.c
+++ b/src/guest/guest.c
@@ -429,6 +429,7 @@ int import_guest(char *in_path)
 			} else if (strcmp(val, VGPU_OPTS_GVTD_STR) == 0) {
 			} else if (strcmp(val, VGPU_OPTS_VIRTIO_STR) == 0) {
 			} else if (strcmp(val, VGPU_OPTS_RAMFB_STR) == 0) {
+			} else if (strcmp(val, VGPU_OPTS_VIRTIO2D_STR) == 0) {
 			} else {
 				g_warning("cannot find graphics sub-key\n");
 				return -1;

--- a/src/guest/start.c
+++ b/src/guest/start.c
@@ -659,6 +659,10 @@ int start_guest(char *name)
 	} else if (strcmp(val, VGPU_OPTS_RAMFB_STR) == 0) {
 		cx = snprintf(p, size, " -display gtk,gl=on -device ramfb");
 		p += cx; size -= cx;
+	} else if (strcmp(val, VGPU_OPTS_VIRTIO2D_STR) == 0) {
+		cx = snprintf(p, size, " -display gtk,gl=on -device virtio-gpu-pci,virgl=off");
+		p += cx; size -= cx;
+		set_aaf_option(AAF_CONFIG_GPU_TYPE, AAF_GPU_TYPE_VIRTIO);
 	} else {
 		g_warning("Invalid Graphics config\n");
 		return -1;

--- a/src/guest/tui.c
+++ b/src/guest/tui.c
@@ -97,7 +97,7 @@ static int pt_selected[PT_MAX] = { 0 };
 static char pt_opts[PT_FIELD_LEN_MAX] = { 0 };
 
 static field_sub_opts_t firmware_sub_opts = 	{ 2, -1, NULL, { FIRM_OPTS_UNIFIED_STR,  FIRM_OPTS_SPLITED_STR } };
-static field_sub_opts_t graphics_sub_opts = 	{ 4, -1, NULL, { VGPU_OPTS_VIRTIO_STR, VGPU_OPTS_RAMFB_STR, VGPU_OPTS_GVTG_STR, VGPU_OPTS_GVTD_STR } };
+static field_sub_opts_t graphics_sub_opts = 	{ 4, -1, NULL, { VGPU_OPTS_VIRTIO_STR, VGPU_OPTS_RAMFB_STR, VGPU_OPTS_GVTG_STR, VGPU_OPTS_GVTD_STR, VGPU_OPTS_VIRTIO2D_STR } };
 static field_sub_opts_t gvtg_sub_opts =     	{ 4, -1, NULL, { GVTG_OPTS_V5_1_STR, GVTG_OPTS_V5_2_STR, GVTG_OPTS_V5_4_STR, GVTG_OPTS_V5_8_STR } };
 static field_sub_opts_t passthrough_sub_opts = 	{ 5, -1, pt_selected, {NULL} };
 static field_sub_opts_t suspend_opts =          { 2, -1, NULL, { SUSPEND_ENABLE_STR, SUSPEND_DISABLE_STR } };
@@ -298,6 +298,8 @@ int set_field_data(form_index_t index, const char *in)
 			graphics_sub_opts.pick_index = VGPU_OPTS_VIRTIO;
 		} else if (strcmp(in, VGPU_OPTS_RAMFB_STR) == 0) {
 			graphics_sub_opts.pick_index = VGPU_OPTS_RAMFB;
+		} else if (strcmp(in, VGPU_OPTS_VIRTIO2D_STR) == 0) {
+			graphics_sub_opts.pick_index = VGPU_OPTS_VIRTIO2D;
 		} else {
 			fprintf(stderr, "Invalid virtual GPU type!\n");
 			return -1;

--- a/src/include/guest/guest.h
+++ b/src/include/guest/guest.h
@@ -74,13 +74,15 @@ enum {
 	VGPU_OPTS_VIRTIO = 0,
 	VGPU_OPTS_RAMFB,
 	VGPU_OPTS_GVTG,
-	VGPU_OPTS_GVTD
+	VGPU_OPTS_GVTD,
+	VGPU_OPTS_VIRTIO2D
 };
 
-#define VGPU_OPTS_VIRTIO_STR   "virtio"
-#define VGPU_OPTS_RAMFB_STR    "ramfb"
-#define VGPU_OPTS_GVTG_STR     "GVT-g"
-#define VGPU_OPTS_GVTD_STR     "GVT-d"
+#define VGPU_OPTS_VIRTIO_STR      "virtio"
+#define VGPU_OPTS_RAMFB_STR       "ramfb"
+#define VGPU_OPTS_GVTG_STR        "GVT-g"
+#define VGPU_OPTS_GVTD_STR        "GVT-d"
+#define VGPU_OPTS_VIRTIO2D_STR    "virtio2d"
 
 enum {
 	GVTG_OPTS_V5_1 = 0,


### PR DESCRIPTION
Add option virtio2d to VM Manager used to start software rendering.

Tracked-On: OAM-101055
Signed-off-by: wei, wushuangx <wushuangx.wei@intel.com>