### PR TITLE
add extra debian install files

### DIFF
--- a/debian/etc/modules-load.d/civ-mods-base.conf
+++ b/debian/etc/modules-load.d/civ-mods-base.conf
@@ -1,0 +1,1 @@
+vhost-vsock

--- a/debian/install
+++ b/debian/install
@@ -1,0 +1,1 @@
+debian/etc/modules-load.d/civ-mods-base.conf /etc/modules-load.d

--- a/debian/rules
+++ b/debian/rules
@@ -15,6 +15,9 @@ override_dh_auto_build:
 override_dh_auto_install:
 	dh_auto_install -- prefix=/usr
 
+override_dh_installudev:
+	dh_installudev --name=civ-base --priority=98
+
 override_dh_clean:
 	dh_clean
 	rm -rf $(BUILD_DIR)

--- a/debian/vm-manager.civ-base.udev
+++ b/debian/vm-manager.civ-base.udev
@@ -1,0 +1,3 @@
+KERNEL=="renderD128", SUBSYSTEM=="drm", MODE="0666"
+KERNEL=="vhost-vsock", SUBSYSTEM=="misc", MODE="0666"
+KERNEL=="kvm", SUBSYSTEM=="misc", MODE="0666"

--- a/debian/vm-manager.postinst
+++ b/debian/vm-manager.postinst
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    configure)
+        udevadm control --reload-rules && udevadm trigger
+        modprobe -r vhost_vsock && modprobe vhost_vsock
+    ;;
+
+    abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
Add udev/rules for vhost-vsock, make the device block
accessable for all user.
Reload vsock driver at post install stage.

Tracked-On: OAM-101205
Signed-off-by: Yadong Qi <yadong.qi@intel.com>