### PR TITLE
Enable Audio Type option in vm-manager

### DIFF
--- a/sample/guest01.ini
+++ b/sample/guest01.ini
@@ -51,6 +51,11 @@ data_dir=/home/gvt/caas
 [aaf]
 path=/home/gvt/caas/scripts/aaf
 support_suspend=enable
+audio_type=legacy-hda
+#audio type must be one of these two options:
+# "legacy-hda" or "sof-hda"
+#Enable "sof-hda" only when "sof-hda" sound card is enabled in the host and you are
+#making audio passthrough for guest. In all other cases use "legacy-hda" only.
 
 [passthrough]
 #specified the PCI id here if you want to passthrough it to guest, seperate them with comma

--- a/src/guest/aaf.c
+++ b/src/guest/aaf.c
@@ -33,6 +33,11 @@ static const char *suspend_support[] = {
 	[AAF_SUSPEND_ENABLE]  = "suspend:true"
 };
 
+static const char *audio_type[] = {
+	[AAF_AUDIO_TYPE_HDA] = "audio-type:legacy-hda",
+	[AAF_AUDIO_TYPE_SOF]  = "audio-type:sof-hda"
+};
+
 static char *aaf_file = NULL;
 
 static const char *aaf_config_array[AAF_CONFIG_NUM] = { NULL };
@@ -99,6 +104,11 @@ int set_aaf_option(aaf_config_opt_t opt, unsigned int sub)
 			if (sub > AAF_SUSPEND_ENABLE)
 				return -1;
 			aaf_config_array[AAF_CONFIG_SUSPEND] = suspend_support[sub];
+			break;
+		case AAF_CONFIG_AUDIO:
+			if (sub > AAF_AUDIO_TYPE_SOF)
+				return -1;
+			aaf_config_array[AAF_CONFIG_AUDIO] = audio_type[sub];
 			break;
 		case AAF_CONFIG_GPU_TYPE:
 			if (sub > AAF_GPU_TYPE_GVTD)

--- a/src/guest/guest.c
+++ b/src/guest/guest.c
@@ -32,7 +32,7 @@ keyfile_group_t g_group[] = {
 	{ "rpmb",     { "bin_path", "data_dir", NULL } },
 	{ "passthrough", { "passthrough_pci", NULL}},
 	{ "mediation", { "battery_med", "thermal_med", NULL }},
-	{ "aaf",      { "path", "support_suspend", NULL } },
+	{ "aaf",      { "path", "support_suspend", "audio_type", NULL } },
 	{ "guest_control", { "time_keep", "pm_control", NULL }},
 	{ "extra",    { "cmd", "service", NULL } },
 };
@@ -138,6 +138,9 @@ int load_form_data(char *name)
 	set_field_data(FORM_INDEX_AAF_PATH, val);
 	val = g_key_file_get_string(in, g->name, g->key[AAF_SUSPEND], NULL);
 	set_field_data(FORM_INDEX_AAF_SUSPEND, val);
+	val = g_key_file_get_string(in, g->name, g->key[AAF_AUDIO_TYPE], NULL);
+	set_field_data(FORM_INDEX_AAF_AUDIO_TYPE, val);
+
 
 	g = &g_group[GROUP_GUEST_SERVICE];
 	val = g_key_file_get_string(in, g->name, g->key[GUEST_TIME_KEEP], NULL);

--- a/src/include/guest/aaf.h
+++ b/src/include/guest/aaf.h
@@ -11,12 +11,18 @@
 typedef enum {
     AAF_CONFIG_GPU_TYPE = 0,
     AAF_CONFIG_SUSPEND,
+    AAF_CONFIG_AUDIO,
     AAF_CONFIG_NUM
 } aaf_config_opt_t;
 
 enum {
     AAF_SUSPEND_DISABLE = 0,
     AAF_SUSPEND_ENABLE
+};
+
+enum {
+    AAF_AUDIO_TYPE_HDA =0,
+    AAF_AUDIO_TYPE_SOF
 };
 
 enum {

--- a/src/include/guest/guest.h
+++ b/src/include/guest/guest.h
@@ -57,6 +57,8 @@ typedef enum {
 	FORM_INDEX_THERMAL_MED,
 	FORM_INDEX_AAF_PATH,
 	FORM_INDEX_AAF_SUSPEND,
+	FORM_INDEX_AAF_AUDIO_TYPE,
+
 	FORM_INDEX_GUEST_TIME_KEEP,
 	FORM_INDEX_PM_CONTROL,
 	FORM_INDEX_EXTRA_CMD,
@@ -70,6 +72,14 @@ enum {
 
 #define FIRM_OPTS_UNIFIED_STR "unified"
 #define FIRM_OPTS_SPLITED_STR "splited"
+
+enum {
+	AUDIO_TYPE_HDA = 0,
+	AUDIO_TYPE_SOF
+};
+
+#define AUDIO_TYPE_HDA_STR "legacy-hda"
+#define AUDIO_TYPE_SOF_STR "sof-hda"
 
 enum {
 	VGPU_OPTS_VIRTIO = 0,
@@ -190,6 +200,7 @@ enum {
   	/* Sub key of group aaf */
 	AAF_PATH = 0,
 	AAF_SUSPEND,
+	AAF_AUDIO_TYPE,
 	
 	/* Guest services */
 	GUEST_TIME_KEEP = 0,


### PR DESCRIPTION
This patch adds options to enable audio type in vm-manager.
Signed-off-by: pmandri <padmashree.mandri@intel.com>