### PR TITLE
Determine vusb size according to total images size

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+vm-manager (0.5.1) stable; urgency=medium
+
+  * Bump version to 0.5.1 
+
+ -- Qi, Yadong <yadong.qi@intel.com>  Fri, 29 Apr 2022 13:08:28 +0800
+
 vm-manager (0.5.0) stable; urgency=medium
 
   * Bump version to 0.5.0

--- a/src/vm_manager.c
+++ b/src/vm_manager.c
@@ -21,7 +21,7 @@
 
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 5
-#define VERSION_MICRO 0
+#define VERSION_MICRO 1
 
 #define VERSION xstr(VERSION_MAJOR)"."xstr(VERSION_MINOR)"."xstr(VERSION_MICRO)
 


### PR DESCRIPTION
The total images' size may change for different usage, so need to
determine the vusb size according to total images' size.

Tracked-On: OAM-102019
Signed-off-by: Yadong Qi <yadong.qi@intel.com>