### PR TITLE
Removing default net configuration in VM manager

### DIFF
--- a/src/guest/start.c
+++ b/src/guest/start.c
@@ -44,7 +44,6 @@ static const char *fixed_cmd =
 	" -device qemu-xhci,id=xhci,p2=8,p3=8"
 	" -device usb-mouse"
 	" -device usb-kbd"
-	" -device e1000,netdev=net0"
 	" -device intel-iommu,device-iotlb=on,caching-mode=on"
 	" -nodefaults ";
 


### PR DESCRIPTION
If we emulate net configuration by default along
with Ethernet passthrough android fastboot will
generate IPV6 address based on emulated net
configuration which results in fastboot connection
failure.

This fix will remove default net configuration
to avoid fastboot connection issue

Tracked-On: OAM-101937
Signed-off-by: Vilas R K <vilas.r.k@intel.com>