### PR TITLE
Revert "Fix the android boot fail with qemu 6.0 on ADL"

### DIFF
--- a/src/guest/start.c
+++ b/src/guest/start.c
@@ -39,7 +39,7 @@ static const char *fixed_cmd =
 	" -M q35"
 	" -machine kernel_irqchip=on"
 	" -k en-us"
-	" -cpu host,-waitpkg"
+	" -cpu host"
 	" -enable-kvm"
 	" -device qemu-xhci,id=xhci,p2=8,p3=8"
 	" -device usb-mouse"


### PR DESCRIPTION
This reverts commit 22d3eb4667af20cdee79893714724cda542c618d.