### PR TITLE
Use argv[0] directly when start server daemon

### DIFF
--- a/src/vm_manager.cc
+++ b/src/vm_manager.cc
@@ -249,9 +249,7 @@ class CivOptions final {
             return StartServer(daemon);
         } else {
             if (!IsServerRunning()) {
-                LOG(info) << "command: " << boost::filesystem::canonical(argv[0]).c_str();
-                boost::filesystem::path cmd = boost::filesystem::canonical(argv[0]);
-                if (boost::process::system(cmd.c_str(), "--start-server", "--daemon")) {
+                if (boost::process::system(argv[0], "--start-server", "--daemon")) {
                     LOG(error) << "Failed to start server of vm-manager!";
                     return false;
                 }


### PR DESCRIPTION
No need to get absolute path of command.

Signed-off-by: Yadong Qi <yadong.qi@intel.com>