### PR TITLE
Update setup with support for Ubuntu 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           export CC=/usr/bin/clang
           export CXX=/usr/bin/clang++
           debuild --preserve-env -b -uc -us --lintian-opts --profile debian
-          cp $(realpath ../*.deb) vm-manager_${{ env.REL_VER }}_${{ matrix.os }}.deb
+          cp $(realpath ../*.deb) vm-manager_${{ env.REL_VER }}.deb
 
       - name: artifacts
         uses: actions/upload-artifact@v2
@@ -53,4 +53,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            vm-manager/vm-manager_${{ env.REL_VER }}_${{ matrix.os }}.deb
+            vm-manager/vm-manager_${{ env.REL_VER }}.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,19 @@ jobs:
       - name: setup
         run: |
           sudo apt-get --quiet update --yes
-          sudo apt-get --quiet install --yes make devscripts build-essential lintian debhelper
+          sudo apt-get --quiet install --yes cmake make devscripts lintian debhelper
+          sudo apt-get --quiet install --yes autoconf libtool pkg-config 
 
       - name: Set release version
         run: echo "REL_VER=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: build
         run: |
+          export PATH="${{ env.LOCAL_INSTALL_DIR }}/bin:$PATH"
+          sudo ln -s $(which cmake) /usr/bin/cmake || echo ""
           cd vm-manager/
+          export CC=/usr/bin/clang
+          export CXX=/usr/bin/clang++
           debuild --preserve-env -b -uc -us --lintian-opts --profile debian
           cp $(realpath ../*.deb) vm-manager_${{ env.REL_VER }}_${{ matrix.os }}.deb
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -102,8 +102,8 @@ options:
 For network emulation.
 requirements:
 - model: optional ethernet model, default is e1000.
-- adb: optional adb forwarding port.
-- fastboot: optional fastboot forwarding port. 
+- adb_port: optional adb forwarding port.
+- fastboot_port: optional fastboot forwarding port. 
 
 
 ### [vtpm]

--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -526,33 +526,38 @@ function setup_sof() {
 }
 
 function ubu_install_swtpm() {
-    TPMS_VER=v0.9.0
-    TPMS_LIB=libtpms-0.9.0
-    SWTPM_VER=v0.7.0
-    SWTPM=swtpm-0.7.0
+    if [[ $(lsb_release -rs) == "22.04" ]]; then
+	#install libtpms and swtpm
+	sudo apt-get -y install libtpms-dev swtpm
+    else
+	TPMS_VER=v0.9.0
+	TPMS_LIB=libtpms-0.9.0
+	SWTPM_VER=v0.7.0
+	SWTPM=swtpm-0.7.0
 
-    #install libtpms
-    apt-get -y install automake autoconf gawk
-    [ ! -f $TPMS_VER.tar.gz ] && wget https://github.com/stefanberger/libtpms/archive/$TPMS_VER.tar.gz -P $CIV_WORK_DIR
-    [ -d $CIV_WORK_DIR/$TPMS_LIB ] && rm -rf  $CIV_WORK_DIR/$TPMS_LIB
-    tar zxvf $CIV_WORK_DIR/$TPMS_VER.tar.gz
-    cd $CIV_WORK_DIR/$TPMS_LIB
-    ./autogen.sh --with-tpm2 --with-openssl --prefix=/usr
-    make -j24
-    make -j24 check
-    make install
-    cd -
+	#install libtpms
+	apt-get -y install automake autoconf gawk
+	[ ! -f $TPMS_VER.tar.gz ] && wget https://github.com/stefanberger/libtpms/archive/$TPMS_VER.tar.gz -P $CIV_WORK_DIR
+	[ -d $CIV_WORK_DIR/$TPMS_LIB ] && rm -rf  $CIV_WORK_DIR/$TPMS_LIB
+	tar zxvf $CIV_WORK_DIR/$TPMS_VER.tar.gz
+	cd $CIV_WORK_DIR/$TPMS_LIB
+	./autogen.sh --with-tpm2 --with-openssl --prefix=/usr
+	make -j24
+	make -j24 check
+	make install
+	cd -
 
-    #install swtpm
-    apt-get -y install net-tools libseccomp-dev libtasn1-6-dev libgnutls28-dev expect libjson-glib-dev
-    [ ! -f $SWTPM_VER.tar.gz ] && wget https://github.com/stefanberger/swtpm/archive/$SWTPM_VER.tar.gz -P $CIV_WORK_DIR
-    [ -d $CIV_WORK_DIR/$SWTPM ] && rm -rf  $CIV_WORK_DIR/$SWTPM
-    tar zxvf $CIV_WORK_DIR/$SWTPM_VER.tar.gz
-    cd $CIV_WORK_DIR/$SWTPM
-    ./autogen.sh --with-openssl --prefix=/usr
-    make -j24
-    make install
-    cd -
+	#install swtpm
+	apt-get -y install net-tools libseccomp-dev libtasn1-6-dev libgnutls28-dev expect libjson-glib-dev
+	[ ! -f $SWTPM_VER.tar.gz ] && wget https://github.com/stefanberger/swtpm/archive/$SWTPM_VER.tar.gz -P $CIV_WORK_DIR
+	[ -d $CIV_WORK_DIR/$SWTPM ] && rm -rf  $CIV_WORK_DIR/$SWTPM
+	tar zxvf $CIV_WORK_DIR/$SWTPM_VER.tar.gz
+	cd $CIV_WORK_DIR/$SWTPM
+	./autogen.sh --with-openssl --prefix=/usr
+	make -j24
+	make install
+	cd -
+    fi
 }
 
 function ubu_update_bt_fw() {

--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -14,7 +14,6 @@ OPENSSL_REL="1.1.1q"
 CIV_WORK_DIR=$(pwd)
 CIV_GOP_DIR=$CIV_WORK_DIR/GOP_PKG
 CIV_VERTICAl_DIR=$CIV_WORK_DIR/vertical_patches/host
-CIV_VIRTIOFSD_REL="virtiofsd-v1.4.0"
 
 #---------      Functions    -------------------
 function error() {
@@ -202,23 +201,10 @@ function ubu_install_qemu_gvt(){
         --enable-gtk \
         --enable-virtfs \
         --target-list=x86_64-softmmu \
-        --enable-virtiofsd \
-        --enable-cap-ng \
-        --enable-seccomp \
-        --enable-libdaxctl \
         --audio-drv-list=pa
     make -j24
     sudo make install
     cd -
-}
-
-function ubu_install_virtiofsd(){
-    echo "download virtiofsd"
-    wget https://gitlab.com/virtio-fs/virtiofsd/uploads/b4a5fbe388739bbd833f822ef9d83e82/$CIV_VIRTIOFSD_REL.zip -P $CIV_WORK_DIR
-    echo "unzip virtiofsd package"
-    unzip -n $CIV_VIRTIOFSD_REL.zip -d $CIV_VIRTIOFSD_REL
-    echo "copy virtiofsd to /usr/bin"
-    sudo cp $CIV_WORK_DIR/$CIV_VIRTIOFSD_REL/target/x86_64-unknown-linux-musl/release/virtiofsd /usr/bin
 }
 
 function ubu_build_ovmf_gvt(){
@@ -726,7 +712,6 @@ install_host_service
 install_virtual_camera
 
 ubu_install_qemu_gvt
-ubu_install_virtiofsd
 ubu_build_ovmf_gvt
 ubu_enable_host_gvt
 ubu_enable_host_sriov

--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -14,6 +14,7 @@ OPENSSL_REL="1.1.1q"
 CIV_WORK_DIR=$(pwd)
 CIV_GOP_DIR=$CIV_WORK_DIR/GOP_PKG
 CIV_VERTICAl_DIR=$CIV_WORK_DIR/vertical_patches/host
+CIV_VIRTIOFSD_REL="virtiofsd-v1.4.0"
 
 #---------      Functions    -------------------
 function error() {
@@ -192,10 +193,23 @@ function ubu_install_qemu_gvt(){
         --enable-gtk \
         --enable-virtfs \
         --target-list=x86_64-softmmu \
+        --enable-virtiofsd \
+        --enable-cap-ng \
+        --enable-seccomp \
+        --enable-libdaxctl \
         --audio-drv-list=pa
     make -j24
     sudo make install
     cd -
+}
+
+function ubu_install_virtiofsd(){
+    echo "download virtiofsd"
+    wget https://gitlab.com/virtio-fs/virtiofsd/uploads/b4a5fbe388739bbd833f822ef9d83e82/$CIV_VIRTIOFSD_REL.zip -P $CIV_WORK_DIR
+    echo "unzip virtiofsd package"
+    unzip -n $CIV_VIRTIOFSD_REL.zip -d $CIV_VIRTIOFSD_REL
+    echo "copy virtiofsd to /usr/bin"
+    sudo cp $CIV_WORK_DIR/$CIV_VIRTIOFSD_REL/target/x86_64-unknown-linux-musl/release/virtiofsd /usr/bin
 }
 
 function ubu_build_ovmf_gvt(){
@@ -698,6 +712,7 @@ install_host_service
 install_virtual_camera
 
 ubu_install_qemu_gvt
+ubu_install_virtiofsd
 ubu_build_ovmf_gvt
 ubu_enable_host_gvt
 ubu_enable_host_sriov

--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -10,6 +10,7 @@ set -eE
 #---------      Global variable     -------------------
 reboot_required=0
 QEMU_REL="qemu-7.0.0"
+OPENSSL_REL="1.1.1q"
 CIV_WORK_DIR=$(pwd)
 CIV_GOP_DIR=$CIV_WORK_DIR/GOP_PKG
 CIV_VERTICAl_DIR=$CIV_WORK_DIR/vertical_patches/host

--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -177,10 +177,6 @@ function ubu_install_qemu_gvt(){
         done
     fi
 
-    if [[ $(lsb_release -rs) == "22.04" ]]; then
-	git apply $CIV_WORK_DIR/patches/qemu/gcc_11/0034-Fix_VLA_parameter_warning.patch
-    fi
-
     ./configure --prefix=/usr \
         --enable-kvm \
         --disable-xen \

--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -225,9 +225,14 @@ function ubu_build_ovmf_gvt(){
 
     git submodule update --init
 
+    if [[ $(lsb_release -rs) == "22.04" ]]; then
+        git apply $CIV_WORK_DIR/patches/qemu/gcc_11/0034-Fix_VLA_parameter_warning.patch
+    fi
+
     source ./edksetup.sh
     make -C BaseTools/
     build -b DEBUG -t GCC5 -a X64 -p OvmfPkg/OvmfPkgX64.dsc -D NETWORK_IP4_ENABLE -D NETWORK_ENABLE  -D SECURE_BOOT_ENABLE -D TPM_ENABLE
+
     cp Build/OvmfX64/DEBUG_GCC5/FV/OVMF.fd ../OVMF.fd
 
     if [ -d $CIV_GOP_DIR ]; then

--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -146,6 +146,10 @@ function ubu_changes_require(){
 function ubu_install_qemu_gvt(){
     sudo apt purge -y "^qemu"
     sudo apt autoremove -y
+<<<<<<< HEAD
+=======
+    
+>>>>>>> ec77a1d (Update setup with support for Ubuntu 22.04)
     if [[ $(lsb_release -rs) == "22.04" ]]; then
         sudo apt install -y git libfdt-dev libpixman-1-dev libssl-dev vim socat libsdl2-dev libspice-server-dev autoconf libtool xtightvncviewer tightvncserver x11vnc uuid-runtime uuid uml-utilities bridge-utils python2-dev liblzma-dev libc6-dev libegl1-mesa-dev libepoxy-dev libdrm-dev libgbm-dev libaio-dev libusb-1.0-0-dev libgtk-3-dev bison libcap-dev libattr1-dev flex libvirglrenderer-dev build-essential gettext libegl-mesa0 libegl-dev libglvnd-dev libgl1-mesa-dev libgl1-mesa-dev libgles2-mesa-dev libegl1 gcc g++ pkg-config libpulse-dev libgl1-mesa-dri libdaxctl-dev
     else
@@ -178,6 +182,10 @@ function ubu_install_qemu_gvt(){
             echo "applying qemu patch $i"
             patch -p1 < $i
         done
+    fi
+
+    if [[ $(lsb_release -rs) == "22.04" ]]; then
+	git apply $CIV_WORK_DIR/patches/qemu/gcc_11/0034-Fix_VLA_parameter_warning.patch
     fi
 
     ./configure --prefix=/usr \

--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -147,10 +147,11 @@ function ubu_install_qemu_gvt(){
     sudo apt purge -y "^qemu"
     sudo apt autoremove -y
     if [[ $(lsb_release -rs) == "22.04" ]]; then
-        sudo apt install -y git libfdt-dev libpixman-1-dev libssl-dev vim socat libsdl2-dev libspice-server-dev autoconf libtool xtightvncviewer tightvncserver x11vnc uuid-runtime uuid uml-utilities bridge-utils python2-dev liblzma-dev libc6-dev libegl1-mesa-dev libepoxy-dev libdrm-dev libgbm-dev libaio-dev libusb-1.0-0-dev libgtk-3-dev bison libcap-dev libattr1-dev flex libvirglrenderer-dev build-essential gettext libegl-mesa0 libegl-dev libglvnd-dev libgl1-mesa-dev libgl1-mesa-dev libgles2-mesa-dev libegl1 gcc g++ pkg-config libpulse-dev libgl1-mesa-dri
+        sudo apt install -y git libfdt-dev libpixman-1-dev libssl-dev vim socat libsdl2-dev libspice-server-dev autoconf libtool xtightvncviewer tightvncserver x11vnc uuid-runtime uuid uml-utilities bridge-utils python2-dev liblzma-dev libc6-dev libegl1-mesa-dev libepoxy-dev libdrm-dev libgbm-dev libaio-dev libusb-1.0-0-dev libgtk-3-dev bison libcap-dev libattr1-dev flex libvirglrenderer-dev build-essential gettext libegl-mesa0 libegl-dev libglvnd-dev libgl1-mesa-dev libgl1-mesa-dev libgles2-mesa-dev libegl1 gcc g++ pkg-config libpulse-dev libgl1-mesa-dri libdaxctl-dev
     else
-       sudo apt install -y git libfdt-dev libpixman-1-dev libssl-dev vim socat libsdl2-dev libspice-server-dev autoconf libtool xtightvncviewer tightvncserver x11vnc uuid-runtime uuid uml-utilities bridge-utils python-dev liblzma-dev libc6-dev libegl1-mesa-dev libepoxy-dev libdrm-dev libgbm-dev libaio-dev libusb-1.0-0-dev libgtk-3-dev bison libcap-dev libattr1-dev flex libvirglrenderer-dev build-essential gettext libegl-mesa0 libegl-dev libglvnd-dev libgl1-mesa-dev libgl1-mesa-dev libgles2-mesa-dev libegl1 gcc g++ pkg-config libpulse-dev libgl1-mesa-dri
+       sudo apt install -y git libfdt-dev libpixman-1-dev libssl-dev vim socat libsdl2-dev libspice-server-dev autoconf libtool xtightvncviewer tightvncserver x11vnc uuid-runtime uuid uml-utilities bridge-utils python-dev liblzma-dev libc6-dev libegl1-mesa-dev libepoxy-dev libdrm-dev libgbm-dev libaio-dev libusb-1.0-0-dev libgtk-3-dev bison libcap-dev libattr1-dev flex libvirglrenderer-dev build-essential gettext libegl-mesa0 libegl-dev libglvnd-dev libgl1-mesa-dev libgl1-mesa-dev libgles2-mesa-dev libegl1 gcc g++ pkg-config libpulse-dev libgl1-mesa-dri libdaxctl-dev
     fi
+    
     sudo apt install -y ninja-build libcap-ng-dev
 
     [ ! -f $CIV_WORK_DIR/$QEMU_REL.tar.xz ] && wget https://download.qemu.org/$QEMU_REL.tar.xz -P $CIV_WORK_DIR

--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -282,7 +282,11 @@ function install_vm_manager_src() {
 function install_vm_manager() {
     sudo apt-get update
     sudo apt-get install --yes libglib2.0-dev libncurses-dev libuuid1 uuid-dev libjson-c-dev wget lsb-release git
-    install_vm_manager_deb || install_vm_manager_src
+    if [[ $(lsb_release -rs) == "22.04" ]]; then
+    	install_vm_manager_src
+    else
+        install_vm_manager_deb || install_vm_manager_src
+    fi
     if [ "$?" -ne 0 ]; then
         echo "Failed to install vm-manager!"
         echo "Please download and install mannually from: https://github.com/projectceladon/vm_manager/releases/"

--- a/src/guest/config_parser.cc
+++ b/src/guest/config_parser.cc
@@ -39,7 +39,7 @@ map<string_view, vector<string_view>> kConfigMap = {
     { kGroupNet,     { kNetModel, kNetAdbPort, kNetFastbootPort } },
     { kGroupVtpm,    { kVtpmBinPath, kVtpmDataDir } },
     { kGroupRpmb,    { kRpmbBinPath, kRpmbDataDir } },
-    { kGroupAaf,     { kAafPath, kAafSuspend }},
+    { kGroupAaf,     { kAafPath, kAafSuspend, kAafAudioType }},
     { kGroupPciPt,   { kPciPtDev }},
     { kGroupMed,     { kMedBattery, kMedThermal, kMedCamera } },
     { kGroupService, { kServTimeKeep, kServPmCtrl } },

--- a/src/guest/config_parser.h
+++ b/src/guest/config_parser.h
@@ -62,8 +62,8 @@ constexpr char kVgpuOutputs[]    = "outputs";
 constexpr char kDispOptions[] = "options";
 
 constexpr char kNetModel[] = "model";
-constexpr char kNetAdbPort[] = "adb";
-inline constexpr char kNetFastbootPort[] = "fastboot";
+constexpr char kNetAdbPort[] = "adb_port";
+constexpr char kNetFastbootPort[] = "fastboot_port";
 
 constexpr char kVtpmBinPath[] = "bin_path";
 constexpr char kVtpmDataDir[] = "data_dir";

--- a/src/guest/vm_builder_qemu.cc
+++ b/src/guest/vm_builder_qemu.cc
@@ -317,7 +317,7 @@ static bool PassthroughOnePciDev(const char *pci_id, PciPassthroughAction action
             while (cnt < kCheckUnbindRepeatCount) {
                 if (!boost::filesystem::exists(driver))
                     break;
-                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                boost::this_thread::sleep_for(boost::chrono::milliseconds(1));
                 cnt++;
             }
             if (cnt >= kCheckUnbindRepeatCount) {


### PR DESCRIPTION
- libavresample is deprecated in favor of libswresample
- added patch for host_camera GCC 11 compile issue
- change python-dev to python2-dev
- added patch to fix ovmf warnings with GCC 11
- added openssl for rpmb_dev feature

Tracked-On: OAM-103716

Signed-off-by: Ionel-Catalin Mititelu <ionel-catalin.mititelu@intel.com>