### PR TITLE
Fix errors when parsing ini files

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -102,8 +102,8 @@ options:
 For network emulation.
 requirements:
 - model: optional ethernet model, default is e1000.
-- adb: optional adb forwarding port.
-- fastboot: optional fastboot forwarding port. 
+- adb_port: optional adb forwarding port.
+- fastboot_port: optional fastboot forwarding port. 
 
 
 ### [vtpm]

--- a/src/guest/config_parser.cc
+++ b/src/guest/config_parser.cc
@@ -39,7 +39,7 @@ map<string_view, vector<string_view>> kConfigMap = {
     { kGroupNet,     { kNetModel, kNetAdbPort, kNetFastbootPort } },
     { kGroupVtpm,    { kVtpmBinPath, kVtpmDataDir } },
     { kGroupRpmb,    { kRpmbBinPath, kRpmbDataDir } },
-    { kGroupAaf,     { kAafPath, kAafSuspend }},
+    { kGroupAaf,     { kAafPath, kAafSuspend, kAafAudioType }},
     { kGroupPciPt,   { kPciPtDev }},
     { kGroupMed,     { kMedBattery, kMedThermal, kMedCamera } },
     { kGroupService, { kServTimeKeep, kServPmCtrl } },

--- a/src/guest/config_parser.h
+++ b/src/guest/config_parser.h
@@ -62,8 +62,8 @@ constexpr char kVgpuOutputs[]    = "outputs";
 constexpr char kDispOptions[] = "options";
 
 constexpr char kNetModel[] = "model";
-constexpr char kNetAdbPort[] = "adb";
-inline constexpr char kNetFastbootPort[] = "fastboot";
+constexpr char kNetAdbPort[] = "adb_port";
+constexpr char kNetFastbootPort[] = "fastboot_port";
 
 constexpr char kVtpmBinPath[] = "bin_path";
 constexpr char kVtpmDataDir[] = "data_dir";


### PR DESCRIPTION
Fix the bug that 'adb_port' and 'audio_type' can't be recognized.

Tracked-on: OAM-103782
Signed-off-by: xinxin-Esme <xinxin.wan@intel.com>