### PR TITLE
Update vsock patch for gRPC

### DIFF
--- a/src/external/patches/grpc/0001-support-vsock_v1.46.2.patch
+++ b/src/external/patches/grpc/0001-support-vsock_v1.46.2.patch
@@ -1,4 +1,4 @@
-From 551395b8bdc8b986621ec4f33424c7588eab488d Mon Sep 17 00:00:00 2001
+From 4398fd93c605216e1f63a07adbaaa07a2fabca59 Mon Sep 17 00:00:00 2001
 From: "Qi, Yadong" <yadong.qi@intel.com>
 Date: Wed, 14 Jul 2021 02:20:36 +0000
 Subject: [PATCH 1/2] support vsock
@@ -7,34 +7,34 @@ Support Virtio-VSOCK
 
 Signed-off-by: Qi, Yadong <yadong.qi@intel.com>
 ---
- BUILD                                         |  2 +
- CMakeLists.txt                                |  2 +
- Makefile                                      |  2 +
- config.m4                                     |  1 +
- gRPC-Core.podspec                             |  2 +
- grpc.gemspec                                  |  2 +
- package.xml                                   |  2 +
- .../ext/filters/client_channel/http_proxy.cc  |  5 +
- .../resolver/sockaddr/README.md               |  2 +-
- .../resolver/sockaddr/sockaddr_resolver.cc    | 24 +++++
- .../transport/chttp2/server/chttp2_server.cc  |  4 +
- src/core/lib/address_utils/parse_address.cc   | 99 +++++++++++++++++++
- src/core/lib/address_utils/parse_address.h    |  8 ++
- src/core/lib/address_utils/sockaddr_utils.cc  | 32 ++++++
- src/core/lib/iomgr/port.h                     |  2 +
- src/core/lib/iomgr/sockaddr_posix.h           |  1 +
- src/core/lib/iomgr/sockaddr_windows.h         |  1 +
- src/core/lib/iomgr/tcp_client_posix.cc        |  3 +-
- .../iomgr/tcp_server_utils_posix_common.cc    |  5 +-
- src/core/lib/iomgr/vsock.cc                   | 74 ++++++++++++++
- src/core/lib/iomgr/vsock.h                    | 40 ++++++++
- src/python/grpcio/grpc_core_dependencies.py   |  1 +
- 22 files changed, 310 insertions(+), 4 deletions(-)
+ BUILD                                         |   2 +
+ CMakeLists.txt                                |   2 +
+ Makefile                                      |   2 +
+ config.m4                                     |   1 +
+ gRPC-Core.podspec                             |   2 +
+ grpc.gemspec                                  |   2 +
+ package.xml                                   |   2 +
+ .../ext/filters/client_channel/http_proxy.cc  |   5 +
+ .../resolver/sockaddr/README.md               |   2 +-
+ .../resolver/sockaddr/sockaddr_resolver.cc    |  24 +++++
+ .../transport/chttp2/server/chttp2_server.cc  |   4 +
+ src/core/lib/address_utils/parse_address.cc   | 100 ++++++++++++++++++
+ src/core/lib/address_utils/parse_address.h    |   8 ++
+ src/core/lib/address_utils/sockaddr_utils.cc  |  32 ++++++
+ src/core/lib/iomgr/port.h                     |   2 +
+ src/core/lib/iomgr/sockaddr_posix.h           |   1 +
+ src/core/lib/iomgr/sockaddr_windows.h         |   1 +
+ src/core/lib/iomgr/tcp_client_posix.cc        |   3 +-
+ .../iomgr/tcp_server_utils_posix_common.cc    |   5 +-
+ src/core/lib/iomgr/vsock.cc                   |  74 +++++++++++++
+ src/core/lib/iomgr/vsock.h                    |  40 +++++++
+ src/python/grpcio/grpc_core_dependencies.py   |   1 +
+ 22 files changed, 311 insertions(+), 4 deletions(-)
  create mode 100644 src/core/lib/iomgr/vsock.cc
  create mode 100644 src/core/lib/iomgr/vsock.h
 
 diff --git a/BUILD b/BUILD
-index c54777bd9f..f3ea6e192c 100644
+index c54777bd9..f3ea6e192 100644
 --- a/BUILD
 +++ b/BUILD
 @@ -1958,6 +1958,7 @@ grpc_cc_library(
@@ -54,7 +54,7 @@ index c54777bd9f..f3ea6e192c 100644
          "src/core/lib/iomgr/wakeup_fd_posix.h",
          "src/core/lib/iomgr/work_serializer.h",
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 5291379eb3..0f8fbeaef7 100644
+index 5291379eb..0f8fbeaef 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -1952,6 +1952,7 @@ add_library(grpc
@@ -74,7 +74,7 @@ index 5291379eb3..0f8fbeaef7 100644
    src/core/lib/iomgr/wakeup_fd_nospecial.cc
    src/core/lib/iomgr/wakeup_fd_pipe.cc
 diff --git a/Makefile b/Makefile
-index 72522e048c..7d52fad293 100644
+index 72522e048..7d52fad29 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -1534,6 +1534,7 @@ LIBGRPC_SRC = \
@@ -94,7 +94,7 @@ index 72522e048c..7d52fad293 100644
      src/core/lib/iomgr/wakeup_fd_nospecial.cc \
      src/core/lib/iomgr/wakeup_fd_pipe.cc \
 diff --git a/config.m4 b/config.m4
-index 51c50bfe57..81d65889ba 100644
+index 51c50bfe5..81d65889b 100644
 --- a/config.m4
 +++ b/config.m4
 @@ -594,6 +594,7 @@ if test "$PHP_GRPC" != "no"; then
@@ -106,7 +106,7 @@ index 51c50bfe57..81d65889ba 100644
      src/core/lib/iomgr/wakeup_fd_nospecial.cc \
      src/core/lib/iomgr/wakeup_fd_pipe.cc \
 diff --git a/gRPC-Core.podspec b/gRPC-Core.podspec
-index 382a0d79a6..c081bec0c4 100644
+index 382a0d79a..c081bec0c 100644
 --- a/gRPC-Core.podspec
 +++ b/gRPC-Core.podspec
 @@ -1271,6 +1271,7 @@ Pod::Spec.new do |s|
@@ -126,7 +126,7 @@ index 382a0d79a6..c081bec0c4 100644
                                'src/core/lib/iomgr/wakeup_fd_posix.h',
                                'src/core/lib/iomgr/work_serializer.h',
 diff --git a/grpc.gemspec b/grpc.gemspec
-index 16a06e6024..88a6a73302 100644
+index 16a06e602..88a6a7330 100644
 --- a/grpc.gemspec
 +++ b/grpc.gemspec
 @@ -1188,6 +1188,8 @@ Gem::Specification.new do |s|
@@ -139,7 +139,7 @@ index 16a06e6024..88a6a73302 100644
    s.files += %w( src/core/lib/iomgr/wakeup_fd_nospecial.cc )
    s.files += %w( src/core/lib/iomgr/wakeup_fd_pipe.cc )
 diff --git a/package.xml b/package.xml
-index d044500cf8..1b4b1820cd 100644
+index d044500cf..1b4b1820c 100644
 --- a/package.xml
 +++ b/package.xml
 @@ -1170,6 +1170,8 @@
@@ -152,7 +152,7 @@ index d044500cf8..1b4b1820cd 100644
      <file baseinstalldir="/" name="src/core/lib/iomgr/wakeup_fd_nospecial.cc" role="src" />
      <file baseinstalldir="/" name="src/core/lib/iomgr/wakeup_fd_pipe.cc" role="src" />
 diff --git a/src/core/ext/filters/client_channel/http_proxy.cc b/src/core/ext/filters/client_channel/http_proxy.cc
-index 72acea58a8..8b9603cf25 100644
+index 72acea58a..8b9603cf2 100644
 --- a/src/core/ext/filters/client_channel/http_proxy.cc
 +++ b/src/core/ext/filters/client_channel/http_proxy.cc
 @@ -151,6 +151,11 @@ bool HttpProxyMapper::MapName(const char* server_uri,
@@ -168,14 +168,14 @@ index 72acea58a8..8b9603cf25 100644
    auto no_proxy_str = UniquePtr<char>(gpr_getenv("no_grpc_proxy"));
    if (no_proxy_str == nullptr) {
 diff --git a/src/core/ext/filters/client_channel/resolver/sockaddr/README.md b/src/core/ext/filters/client_channel/resolver/sockaddr/README.md
-index e307ba88f5..210ffdf3ad 100644
+index e307ba88f..210ffdf3a 100644
 --- a/src/core/ext/filters/client_channel/resolver/sockaddr/README.md
 +++ b/src/core/ext/filters/client_channel/resolver/sockaddr/README.md
 @@ -1 +1 @@
 -Support for resolving ipv4:, ipv6:, unix: schemes
 +Support for resolving ipv4:, ipv6:, unix:, vsock: schemes
 diff --git a/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc b/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
-index d893f2d5f6..3206f83e8f 100644
+index d893f2d5f..3206f83e8 100644
 --- a/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
 +++ b/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
 @@ -178,6 +178,26 @@ class UnixAbstractResolverFactory : public ResolverFactory {
@@ -217,7 +217,7 @@ index d893f2d5f6..3206f83e8f 100644
  
  }  // namespace grpc_core
 diff --git a/src/core/ext/transport/chttp2/server/chttp2_server.cc b/src/core/ext/transport/chttp2/server/chttp2_server.cc
-index 12173a09c0..6a8361fbaf 100644
+index 12173a09c..6a8361fba 100644
 --- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
 +++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
 @@ -51,6 +51,7 @@
@@ -246,7 +246,7 @@ index 12173a09c0..6a8361fbaf 100644
        resolved_or = GetDNSResolver()->ResolveNameBlocking(parsed_addr, "https");
      }
 diff --git a/src/core/lib/address_utils/parse_address.cc b/src/core/lib/address_utils/parse_address.cc
-index 340bab9682..b01dcf74a3 100644
+index 340bab968..a6977d595 100644
 --- a/src/core/lib/address_utils/parse_address.cc
 +++ b/src/core/lib/address_utils/parse_address.cc
 @@ -25,6 +25,10 @@
@@ -260,7 +260,7 @@ index 340bab9682..b01dcf74a3 100644
  #ifdef GRPC_POSIX_SOCKET
  #include <errno.h>
  #include <net/if.h>
-@@ -146,6 +150,98 @@ grpc_error_handle UnixAbstractSockaddrPopulate(
+@@ -146,6 +150,99 @@ grpc_error_handle UnixAbstractSockaddrPopulate(
  }  // namespace grpc_core
  #endif /* GRPC_HAVE_UNIX_SOCKET */
  
@@ -287,6 +287,7 @@ index 340bab9682..b01dcf74a3 100644
 +
 +grpc_error_handle VSockaddrPopulate(absl::string_view cidport,
 +                                       grpc_resolved_address* resolved_addr) {
++  memset(resolved_addr, 0, sizeof(*resolved_addr));
 +  struct sockaddr_vm* vm =
 +      reinterpret_cast<struct sockaddr_vm*>(resolved_addr->addr);
 +
@@ -359,7 +360,7 @@ index 340bab9682..b01dcf74a3 100644
  bool grpc_parse_ipv4_hostport(absl::string_view hostport,
                                grpc_resolved_address* addr, bool log_errors) {
    bool success = false;
-@@ -301,6 +397,9 @@ bool grpc_parse_uri(const grpc_core::URI& uri,
+@@ -301,6 +398,9 @@ bool grpc_parse_uri(const grpc_core::URI& uri,
    if (uri.scheme() == "unix-abstract") {
      return grpc_parse_unix_abstract(uri, resolved_addr);
    }
@@ -370,7 +371,7 @@ index 340bab9682..b01dcf74a3 100644
      return grpc_parse_ipv4(uri, resolved_addr);
    }
 diff --git a/src/core/lib/address_utils/parse_address.h b/src/core/lib/address_utils/parse_address.h
-index 4b18ed6d06..f3362eb0f8 100644
+index 4b18ed6d0..f3362eb0f 100644
 --- a/src/core/lib/address_utils/parse_address.h
 +++ b/src/core/lib/address_utils/parse_address.h
 @@ -38,6 +38,11 @@ bool grpc_parse_unix(const grpc_core::URI& uri,
@@ -396,7 +397,7 @@ index 4b18ed6d06..f3362eb0f8 100644
  
  #endif /* GRPC_CORE_LIB_ADDRESS_UTILS_PARSE_ADDRESS_H */
 diff --git a/src/core/lib/address_utils/sockaddr_utils.cc b/src/core/lib/address_utils/sockaddr_utils.cc
-index ac84a14431..922d0f1401 100644
+index ac84a1443..922d0f140 100644
 --- a/src/core/lib/address_utils/sockaddr_utils.cc
 +++ b/src/core/lib/address_utils/sockaddr_utils.cc
 @@ -41,6 +41,11 @@
@@ -467,7 +468,7 @@ index ac84a14431..922d0f1401 100644
      default:
        gpr_log(GPR_ERROR, "Unknown socket family %d in grpc_sockaddr_get_port",
 diff --git a/src/core/lib/iomgr/port.h b/src/core/lib/iomgr/port.h
-index 8762791e79..8ce1c5ee6a 100644
+index 8762791e7..8ce1c5ee6 100644
 --- a/src/core/lib/iomgr/port.h
 +++ b/src/core/lib/iomgr/port.h
 @@ -36,6 +36,7 @@
@@ -487,7 +488,7 @@ index 8762791e79..8ce1c5ee6a 100644
     the socket option on older kernels. */
  #define GRPC_HAVE_TCP_INQ 1
 diff --git a/src/core/lib/iomgr/sockaddr_posix.h b/src/core/lib/iomgr/sockaddr_posix.h
-index 3cedd9082d..3b97123cc8 100644
+index 3cedd9082..3b97123cc 100644
 --- a/src/core/lib/iomgr/sockaddr_posix.h
 +++ b/src/core/lib/iomgr/sockaddr_posix.h
 @@ -45,6 +45,7 @@ typedef struct in6_addr grpc_in6_addr;
@@ -499,7 +500,7 @@ index 3cedd9082d..3b97123cc8 100644
  #define GRPC_AF_INET6 AF_INET6
  
 diff --git a/src/core/lib/iomgr/sockaddr_windows.h b/src/core/lib/iomgr/sockaddr_windows.h
-index 4d637251a1..298c2e80f3 100644
+index 4d637251a..298c2e80f 100644
 --- a/src/core/lib/iomgr/sockaddr_windows.h
 +++ b/src/core/lib/iomgr/sockaddr_windows.h
 @@ -45,6 +45,7 @@ typedef struct in6_addr grpc_in6_addr;
@@ -511,7 +512,7 @@ index 4d637251a1..298c2e80f3 100644
  #define GRPC_AF_INET6 AF_INET6
  
 diff --git a/src/core/lib/iomgr/tcp_client_posix.cc b/src/core/lib/iomgr/tcp_client_posix.cc
-index 92e9c70dfd..d9316d7bc7 100644
+index 92e9c70df..d9316d7bc 100644
 --- a/src/core/lib/iomgr/tcp_client_posix.cc
 +++ b/src/core/lib/iomgr/tcp_client_posix.cc
 @@ -46,6 +46,7 @@
@@ -532,7 +533,7 @@ index 92e9c70dfd..d9316d7bc7 100644
      if (err != GRPC_ERROR_NONE) goto error;
      err = grpc_set_socket_reuse_addr(fd, 1);
 diff --git a/src/core/lib/iomgr/tcp_server_utils_posix_common.cc b/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
-index d0956db3ad..fc23ecf68c 100644
+index d0956db3a..fc23ecf68 100644
 --- a/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
 +++ b/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
 @@ -41,6 +41,7 @@
@@ -563,7 +564,7 @@ index d0956db3ad..fc23ecf68c 100644
      err = grpc_set_socket_reuse_addr(fd, 1);
 diff --git a/src/core/lib/iomgr/vsock.cc b/src/core/lib/iomgr/vsock.cc
 new file mode 100644
-index 0000000000..511e9a928c
+index 000000000..511e9a928
 --- /dev/null
 +++ b/src/core/lib/iomgr/vsock.cc
 @@ -0,0 +1,74 @@
@@ -643,7 +644,7 @@ index 0000000000..511e9a928c
 +#endif
 diff --git a/src/core/lib/iomgr/vsock.h b/src/core/lib/iomgr/vsock.h
 new file mode 100644
-index 0000000000..e89d4b9099
+index 000000000..e89d4b909
 --- /dev/null
 +++ b/src/core/lib/iomgr/vsock.h
 @@ -0,0 +1,40 @@
@@ -688,7 +689,7 @@ index 0000000000..e89d4b9099
 +
 +#endif /* GRPC_CORE_LIB_IOMGR_VSOCK_H */
 diff --git a/src/python/grpcio/grpc_core_dependencies.py b/src/python/grpcio/grpc_core_dependencies.py
-index 09dffdf730..b543cd1665 100644
+index 09dffdf73..b543cd166 100644
 --- a/src/python/grpcio/grpc_core_dependencies.py
 +++ b/src/python/grpcio/grpc_core_dependencies.py
 @@ -569,6 +569,7 @@ CORE_SOURCE_FILES = [
@@ -700,5 +701,5 @@ index 09dffdf730..b543cd1665 100644
      'src/core/lib/iomgr/wakeup_fd_nospecial.cc',
      'src/core/lib/iomgr/wakeup_fd_pipe.cc',
 -- 
-2.25.1
+2.34.1
 


### PR DESCRIPTION
Clear resolved_addr before using in VSockaddrPopulate().

Tracked-On: OAM-103802
Signed-off-by: Yadong Qi <yadong.qi@intel.com>