### PR TITLE
increase default ram size and cpu cores

### DIFF
--- a/sample/civ-1.ini
+++ b/sample/civ-1.ini
@@ -7,10 +7,10 @@ flashfiles=/home/ubuntu/caas/caas-flashfiles-CRe011396.zip
 path=/usr/bin/qemu-system-x86_64
     
 [memory]
-size=4G
+size=8G
     
 [vcpu]
-num=1
+num=4
     
 [firmware]
 type=unified


### PR DESCRIPTION
default ram size increased to 8GB to avoid random low memory situations and cpu cores to 4 for better performance

Tracked-On: OAM-104181
Signed-off-by: Chenthati, Pradeep <pradeepx.chenthati@intel.com>