### PR TITLE
Update logic for removing snd-sof-pci-intel-tgl

### DIFF
--- a/src/guest/vm_builder_qemu.cc
+++ b/src/guest/vm_builder_qemu.cc
@@ -84,7 +84,7 @@ void VmBuilderQemu::SoundCardHook(void) {
         passthrough when sof-hda is enabled on host and reinsert
         snd-sof-pci-intel-tgl module before exit from guest.
     */
-    if (!boost::process::system("cat /proc/asound/cards | grep sof")) {
+    if (!boost::process::system("ls /proc/asound/sofhdadsp")) {
         LOG(info) << "Removing snd-sof-pci-intel-tgl ...";
         if (!boost::process::system("modprobe -r snd-sof-pci-intel-tgl")) {
             end_call_.emplace([](){


### PR DESCRIPTION
Update logic to remove snd-sof-pci-intel-tgl module, in order to avoid kernel crash while launching android ( only when sof-hda is enabled on host).

Tracked-On: OAM-104431
Signed-off-by: pmandri <padmashree.mandri@intel.com>