### PR TITLE
Update the SRIOV fw for kernel 5.15 host

### DIFF
--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -196,21 +196,20 @@ function ubu_enable_host_sriov(){
 }
 
 function ubu_update_fw(){
-    FW_REL="linux-firmware-20220310"
-    GUC_REL="70.0.3"
-    HUC_REL="7.9.3"
-    S_DMC_REL="2_01"
-    P_DMC_REL="2_12"
+    FW_REL="linux-firmware-20221109"
+    GUC_REL="70"
+    TGL_GUC_REL="70.1.1"
+    S_DMC_REL="2_12"
+    P_DMC_REL="2_16"
+    TGL_HUC_REL="7.9.3"
 
-    [ ! -f $CIV_WORK_DIR/$FW_REL.tar.xz ] && wget "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware-20220310.tar.gz" -P $CIV_WORK_DIR
+    [ ! -f $CIV_WORK_DIR/$FW_REL.tar.xz ] && wget "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware-20221109.tar.gz" -P $CIV_WORK_DIR
 
     [ -d $CIV_WORK_DIR/$FW_REL ] && rm -rf $CIV_WORK_DIR/$FW_REL
     tar -xf $CIV_WORK_DIR/$FW_REL.tar.gz
 
     cd $CIV_WORK_DIR/$FW_REL/i915/
-    wget https://github.com/intel/intel-linux-firmware/raw/main/adlp_guc_$GUC_REL.bin
-    wget https://github.com/intel/intel-linux-firmware/raw/main/tgl_guc_$GUC_REL.bin
-    cp adlp_guc_$GUC_REL.bin tgl_guc_$GUC_REL.bin adlp_dmc_ver$P_DMC_REL.bin adls_dmc_ver$S_DMC_REL.bin tgl_huc_$HUC_REL.bin /lib/firmware/i915/
+    cp adlp_guc_$GUC_REL.bin tgl_guc_$GUC_REL.bin dg2_guc_$GUC_REL.bin tgl_guc_$TGL_GUC_REL.bin adlp_dmc_ver$P_DMC_REL.bin tgl_dmc_ver$S_DMC_REL.bin tgl_huc_$TGL_HUC_REL.bin dg2_huc_gsc.bin tgl_huc.bin /lib/firmware/i915/
 
     cd $CIV_WORK_DIR
     rm -rf $CIV_WORK_DIR/$FW_REL*


### PR DESCRIPTION
The SRIOV guest kernel upgrade to 5.15, the host fw need upgrade too.

Tracked-On: OAM-105008
Signed-off-by: HeYue <yue.he@intel.com>