### PR TITLE
Update action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-20.04]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: vm-manager
 
@@ -39,7 +39,7 @@ jobs:
           debuild --preserve-env -b -uc -us --lintian-opts --profile debian
 
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: vm-manager.${{ matrix.os }}.${{ github.run_id }}.${{ github.sha }}
           path: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: vm-manager
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-20.04]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: vm-manager
 
@@ -38,7 +38,7 @@ jobs:
           cp $(realpath ../*.deb) vm-manager_${{ env.REL_VER }}.deb
 
       - name: artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: vm-manager.${{ matrix.os }}.${{ github.run_id }}.${{ github.sha }}
           path: |


### PR DESCRIPTION
Update action version according to:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Tracked-On: OAM-105091
Signed-off-by: Yadong Qi <yadong.qi@intel.com>