### PR TITLE
Fix GuC loading failing on ubuntu host side

### DIFF
--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -197,19 +197,13 @@ function ubu_enable_host_sriov(){
 
 function ubu_update_fw(){
     FW_REL="linux-firmware-20221109"
-    GUC_REL="70"
-    TGL_GUC_REL="70.1.1"
-    S_DMC_REL="2_12"
-    P_DMC_REL="2_16"
-    TGL_HUC_REL="7.9.3"
 
     [ ! -f $CIV_WORK_DIR/$FW_REL.tar.xz ] && wget "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware-20221109.tar.gz" -P $CIV_WORK_DIR
 
     [ -d $CIV_WORK_DIR/$FW_REL ] && rm -rf $CIV_WORK_DIR/$FW_REL
     tar -xf $CIV_WORK_DIR/$FW_REL.tar.gz
 
-    cd $CIV_WORK_DIR/$FW_REL/i915/
-    cp adlp_guc_$GUC_REL.bin tgl_guc_$GUC_REL.bin dg2_guc_$GUC_REL.bin tgl_guc_$TGL_GUC_REL.bin adlp_dmc_ver$P_DMC_REL.bin tgl_dmc_ver$S_DMC_REL.bin tgl_huc_$TGL_HUC_REL.bin dg2_huc_gsc.bin tgl_huc.bin /lib/firmware/i915/
+    cp -r $CIV_WORK_DIR/$FW_REL/i915/ /lib/firmware/
 
     cd $CIV_WORK_DIR
     rm -rf $CIV_WORK_DIR/$FW_REL*


### PR DESCRIPTION
Guc loading error seen in host dmesg logs
    GuC firmware i915/adlp_guc_70.1.1.bin: fetch failed with error -2
    [drm] GuC firmware i915/adlp_guc_70.1.1.bin version 0.0
    GuC initialization failed -2

Fix the issue by copying all the firmware files present in the i915 folder to /lib/firmware/i915 instead of copying selective files.

Tracked-On: OAM-105224
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>