### PR TITLE
support of usb-tablet mode in qemu.

### DIFF
--- a/src/guest/start.c
+++ b/src/guest/start.c
@@ -42,7 +42,7 @@ static const char *fixed_cmd =
 	" -cpu host,-waitpkg"
 	" -enable-kvm"
 	" -device qemu-xhci,id=xhci,p2=8,p3=8"
-	" -device usb-mouse"
+	" -device usb-tablet"
 	" -device usb-kbd"
 	" -device intel-iommu,device-iotlb=on,caching-mode=on"
 	" -nodefaults ";


### PR DESCRIPTION
replaced usb-mouse with usb-tablet to support
absolute coordinates.Pointer device that uses
absolute coordinates(like touchscreen).This
means QEMU is able to report the mouse position
without having to grab the mouse. Also overrides
the PS/2 mouse emulation when activated.

Tracked-On: OAM-105231
Signed-off-by: Rajani Ranjan <rajani.ranjan@intel.com>