### PR TITLE
Disable net emulation when net.model==none

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+vm-manager (1.1.0) stable; urgency=medium
+
+  * Bump version to 1.1.0
+
+ -- Qi, Yadong <yadong.qi@intel.com>  Tue, 13 Dec 2022 14:20:47 +0800
+
 vm-manager (1.0.3) stable; urgency=medium
 
   * Bump version to 1.0.3

--- a/src/guest/vm_builder_qemu.cc
+++ b/src/guest/vm_builder_qemu.cc
@@ -573,6 +573,9 @@ void VmBuilderQemu::BuildNetCmd(void) {
     if (model.empty())
         model = "e1000";
 
+    if (model.compare("none") == 0)
+        return;
+
     std::string net_arg = " -netdev user,id=net0";
     std::string adb_port = cfg_.GetValue(kGroupNet, kNetAdbPort);
     if (!adb_port.empty())

--- a/src/vm_manager.cc
+++ b/src/vm_manager.cc
@@ -25,8 +25,8 @@
 #include "services/client.h"
 
 #define VERSION_MAJOR 1
-#define VERSION_MINOR 0
-#define VERSION_MICRO 3
+#define VERSION_MINOR 1
+#define VERSION_MICRO 0
 
 namespace vm_manager {
 


### PR DESCRIPTION
when net.model==none, there should no net emulation.

Tracked-On: OAM-105246
Signed-off-by: Yadong Qi <yadong.qi@intel.com>