### PR TITLE
unset SOURCE_DATE_EPOCH to get current date

### DIFF
--- a/src/cmake/revisionCMake.cmake
+++ b/src/cmake/revisionCMake.cmake
@@ -39,6 +39,7 @@ message(STATUS "Build version: ${build_version_}")
 set(build_type_ ${CMAKE_BUILD_TYPE})
 message(STATUS "BUILD Type: ${build_type_}")
 
+unset(ENV{SOURCE_DATE_EPOCH})
 string(TIMESTAMP time_stamp_ UTC)
 message(STATUS "BUILD TimeStamp: ${time_stamp_}")
 


### PR DESCRIPTION
When SOURCE_DATE_EPOCH is set, TIMESTAMP will use this to generate fixed time stamp. 
Here clear this env to get the build timestamp.

Tracked-On: OAM-105301
Signed-off-by: Yadong Qi <yadong.qi@intel.com>