### PR TITLE
Disable PMU emulation for guest in case of vmentry failure

### DIFF
--- a/src/guest/vm_builder_qemu.cc
+++ b/src/guest/vm_builder_qemu.cc
@@ -542,7 +542,7 @@ void VmBuilderQemu::BuildFixedCmd(void) {
         " -M q35"
         " -machine kernel_irqchip=on"
         " -k en-us"
-        " -cpu host,-waitpkg"
+        " -cpu host,-waitpkg,pmu=off"
         " -enable-kvm"
         " -device qemu-xhci,id=xhci,p2=8,p3=8"
         " -device usb-mouse"


### PR DESCRIPTION
In kernel, hybrid PMU set according to CPU family which cause MSRs hardcoded when ADL/RPL detected. And finally cause KVM check vmentry failure.

Currently, there is a kernel patch to disable PMU when in VM and ADL detected:
https://github.com/projectceladon/vendor-intel-utils/blob/master/bsp_diff/common/kernel/lts2021-chromium/0020-Skip-hw-pmu-for-VM-on-ADL.patch

In this patch, we will disable PMU from qemu side to avoid future platform enabling issue. We may need to revisit this if guest need PMU feature.

Tracked-On: OAM-105268
Signed-off-by: Yadong Qi <yadong.qi@intel.com>