### PR TITLE
Use error_code for functions of boost::filesystem

### DIFF
--- a/src/guest/aaf.cc
+++ b/src/guest/aaf.cc
@@ -45,7 +45,7 @@ void Aaf::Flush(void) {
     std::string target_file(path_ + "/" + "mixins.spec");
     std::ofstream out;
 
-    if (boost::filesystem::exists(target_file)) {
+    if (boost::filesystem::exists(target_file, ec)) {
         std::string hidden_file(path_ + "/" + ".mixins.spec~");
         boost::filesystem::rename(target_file, hidden_file, ec);
         std::ifstream in(hidden_file, std::ios::in);
@@ -68,7 +68,7 @@ void Aaf::Flush(void) {
             }
         }
         in.close();
-        boost::filesystem::remove(hidden_file);
+        boost::filesystem::remove(hidden_file, ec);
     }
 
     if (!out.is_open()) {

--- a/src/guest/config_parser.cc
+++ b/src/guest/config_parser.cc
@@ -67,12 +67,13 @@ bool CivConfig::SanitizeOpts(void) {
 }
 
 bool CivConfig::ReadConfigFile(std::string path) {
-    if (!boost::filesystem::exists(path)) {
+    boost::system::error_code ec;
+    if (!boost::filesystem::exists(path, ec)) {
         LOG(error) << "File not exists: " << path << std::endl;
         return false;
     }
 
-    if (!boost::filesystem::is_regular_file(path)) {
+    if (!boost::filesystem::is_regular_file(path, ec)) {
         LOG(error) << "File is not a regular file: " << path << std::endl;
         return false;
     }
@@ -88,12 +89,13 @@ bool CivConfig::ReadConfigFile(std::string path) {
 }
 
 bool CivConfig::WriteConfigFile(std::string path) {
-    if (!boost::filesystem::exists(path)) {
+    boost::system::error_code ec;
+    if (!boost::filesystem::exists(path, ec)) {
         LOG(error) << "File not exists: " << path << std::endl;
         return false;
     }
 
-    if (!boost::filesystem::is_regular_file(path)) {
+    if (!boost::filesystem::is_regular_file(path, ec)) {
         LOG(error) << "File is not a regular file: " << path << std::endl;
         return false;
     }

--- a/src/guest/tui.cc
+++ b/src/guest/tui.cc
@@ -188,7 +188,8 @@ void CivTui::InitializeButtons(void) {
     SaveOn = [&]() {
         std::string configPath = GetConfigPath();
         std::string filePath = configPath + "/" + filename_ +".ini";
-        if (!boost::filesystem::exists(filePath)) {
+        boost::system::error_code ec;
+        if (!boost::filesystem::exists(filePath, ec)) {
             boost::filesystem::ofstream file(filePath);
             SetConfToPtree();
             bool writeConfigFile = civ_config_.WriteConfigFile(filePath);

--- a/src/guest/vm_flash.cc
+++ b/src/guest/vm_flash.cc
@@ -46,7 +46,7 @@ bool VmFlasher::CheckImages(boost::filesystem::path o_dir) {
                     LOG(error) << "Failed to split: " << ditr->path().string();
                     return false;
                 }
-                boost::filesystem::remove(ditr->path().string());
+                boost::filesystem::remove(ditr->path().string(), bec);
             }
         }
     }
@@ -74,7 +74,7 @@ bool VmFlasher::QemuCreateVirtUsbDisk(void) {
     boost::filesystem::path o_dir("/tmp/" + file.stem().string());
     std::error_code ec;
     std::string cmd;
-    if (boost::filesystem::exists(o_dir)) {
+    if (boost::filesystem::exists(o_dir, bec)) {
         cmd.assign("rm -rf " + o_dir.string());
         LOG(info) << cmd;
         if (boost::process::system(cmd))
@@ -89,7 +89,7 @@ bool VmFlasher::QemuCreateVirtUsbDisk(void) {
     }
 
     boost::filesystem::path boot_file(o_dir.string() + "/boot.img");
-    if (boost::filesystem::exists(boot_file)) {
+    if (boost::filesystem::exists(boot_file, bec)) {
         if (!CheckImages(o_dir))
             return false;
 
@@ -110,7 +110,7 @@ bool VmFlasher::QemuCreateVirtUsbDisk(void) {
         }
 
         boost::filesystem::directory_iterator end_itr;
-        for (boost::filesystem::directory_iterator ditr(o_dir); ditr != end_itr; ++ditr) {
+        for (boost::filesystem::directory_iterator ditr(o_dir, bec); ditr != end_itr; ++ditr) {
             if (boost::filesystem::is_regular_file(ditr->path(), bec)) {
                 cmd.assign("mcopy -o -n -i " + std::string(kVirtualUsbDiskPath) + " " + ditr->path().string() + " ::");
                 LOG(info) << cmd;
@@ -131,7 +131,7 @@ bool VmFlasher::QemuCreateVirtUsbDisk(void) {
     }
 
     int count = 0;
-    for (auto& p : boost::filesystem::directory_iterator(o_dir)) {
+    for (auto& p : boost::filesystem::directory_iterator(o_dir, bec)) {
         if (++count >1)
             return false;
     }
@@ -184,7 +184,7 @@ bool VmFlasher::FlashWithQemu(void) {
     std::unique_ptr<VmCoProcRpmb> rpmb_proc;
     boost::system::error_code ec;
     if (!rpmb_bin.empty() && !rpmb_data_dir.empty()) {
-        if (boost::filesystem::exists(rpmb_data_file)) {
+        if (boost::filesystem::exists(rpmb_data_file, ec)) {
             if (!boost::filesystem::remove(rpmb_data_file, ec)) {
                 LOG(error) << "Failed to remove " << rpmb_data_file;
                 LOG(error) << "Please manully remove " << rpmb_data_file << ", and try again!";

--- a/src/guest/vm_process.cc
+++ b/src/guest/vm_process.cc
@@ -105,15 +105,16 @@ void VmProcSimple::SetLogDir(const char *path) {
         return;
 
     boost::filesystem::path p(path);
-    if (boost::filesystem::exists(p)) {
-        if (!boost::filesystem::is_directory(p))
+    boost::system::error_code ec;
+    if (boost::filesystem::exists(p, ec)) {
+        if (!boost::filesystem::is_directory(p, ec))
             return;
     } else {
-        if (!boost::filesystem::create_directories(p))
+        if (!boost::filesystem::create_directories(p, ec))
             return;
     }
 
-    log_dir_.assign(boost::filesystem::absolute(p).c_str()).append("/");
+    log_dir_.assign(boost::filesystem::absolute(p, ec).c_str()).append("/");
 }
 
 void VmProcSimple::Stop(void) {
@@ -149,7 +150,8 @@ VmProcSimple::~VmProcSimple() {
 
 void VmCoProcRpmb::Run(void) {
     LOG(info) << bin_ << " " << data_dir_;
-    if (!boost::filesystem::exists(data_dir_ + "/" + kRpmbData)) {
+    boost::system::error_code bec;
+    if (!boost::filesystem::exists(data_dir_ + "/" + kRpmbData), bec) {
         std::error_code ec;
         boost::process::child init_data(bin_ + " --dev " + data_dir_ + "/" + kRpmbData + " --init --size 2048");
         init_data.wait(ec);
@@ -167,7 +169,8 @@ void VmCoProcRpmb::Stop(void) {
              when exit, so here check and remove the sock file after the rpmb_dev process
              exited. Need to remove this block of code once the rpmb_dev fixed the issue.
      */
-    if (boost::filesystem::exists(sock_file_)) {
+    boost::system::error_code bec;
+    if (boost::filesystem::exists(sock_file_, bec)) {
         LOG(info) << "Cleanup Rpmb CoProc stuff ...";
         boost::filesystem::remove(sock_file_);
     }
@@ -181,7 +184,8 @@ VmCoProcRpmb::~VmCoProcRpmb() {
 void VmCoProcVtpm::Run(void) {
     LOG(info) << bin_ << " " << data_dir_;
 
-    if (!boost::filesystem::exists(data_dir_)) {
+    boost::system::error_code bec;
+    if (!boost::filesystem::exists(data_dir_, bec)) {
         LOG(warning) << "Data path for Vtpm not exists!";
         return;
     }

--- a/src/utils/utils.cc
+++ b/src/utils/utils.cc
@@ -63,9 +63,10 @@ const char *GetConfigPath(void) {
     if (ret != 0 || presult == NULL)
         return NULL;
 
+    boost::system::error_code ec;
     snprintf(civ_config_path, MAX_PATH, "%s%s", pwd.pw_dir, "/.intel/.civ");
-    if (!boost::filesystem::exists(civ_config_path)) {
-        if (!boost::filesystem::create_directories(civ_config_path)) {
+    if (!boost::filesystem::exists(civ_config_path, ec)) {
+        if (!boost::filesystem::create_directories(civ_config_path, ec)) {
             delete[] civ_config_path;
             civ_config_path = NULL;
         }

--- a/src/vm_manager.cc
+++ b/src/vm_manager.cc
@@ -252,7 +252,8 @@ class CivOptions final {
         } else {
             if (!IsServerRunning()) {
                 boost::filesystem::path cmd(args[0]);
-                if (!boost::filesystem::exists(cmd)) {
+                boost::system::error_code ec;
+                if (!boost::filesystem::exists(cmd, ec)) {
                     cmd.assign(boost::process::search_path(args[0]));
                 }
                 if (boost::process::system(cmd, "--start-server", "--daemon")) {


### PR DESCRIPTION
Use error_code for all functions of boost::filesystem to avoid exception.

Signed-off-by: Yadong Qi <yadong.qi@intel.com>