### PR TITLE
Enable ai-dispatcher raw tensor service with vsock

### DIFF
--- a/scripts/Security.md
+++ b/scripts/Security.md
@@ -1,0 +1,9 @@
+# Security Policy
+Intel is committed to rapidly addressing security vulnerabilities affecting our customers and providing clear guidance on the solution, impact, severity and mitigation. 
+
+## Reporting a Vulnerability
+Please report any security vulnerabilities in this project [utilizing the guidelines here](https://www.intel.com/content/www/us/en/security-center/vulnerability-handling-guidelines.html).
+
+## Remote Infer solution is only Pre-Production compliant
+ai_raw_tensor.sh, setup_ai_dispatcher.sh are part of the remote_infer solution which uses [ai-dispatcher](https://github.com/projectceladon/ai-dispatcher/).
+This solution is meant for test or evaluation purposes only, and shouldn't be used in production environments.

--- a/scripts/ai_raw_tensor.sh
+++ b/scripts/ai_raw_tensor.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Intel Corporation.
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -eE
+
+#---------      Global variable     -------------------
+CIV_WORK_DIR=$(pwd)
+AI_DISPATCHER_DIR=$CIV_WORK_DIR/ai-dispatcher
+MODEL_DIR=$AI_DISPATCHER_DIR/model
+SERVICE_DIR=$AI_DISPATCHER_DIR/services/rawTensor
+PROTO_FILE=nnhal_raw_tensor.proto
+SERVER_FILE=$SERVICE_DIR/rawTensor.py
+
+#---------      Functions      -------------------
+function run_python_utility() {
+    export PYTHONPATH="$PYTHONPATH:/home/$SUDO_USER/.local/bin:$AI_DISPATCHER_DIR"
+    if [ ! -e "$SERVICE_DIR/$PROTO_FILE" ]; then
+        echo "Not able to generate python files for the proto file"
+        exit -1
+    else
+        python3 -m grpc_tools.protoc -I $SERVICE_DIR --python_out=$SERVICE_DIR --grpc_python_out=$SERVICE_DIR --proto_path=$SERVICE_DIR $PROTO_FILE
+    fi
+
+    if [ ! -f $SERVER_FILE ] && [ ! -f $LOAD_MODEL_FILE ] && [ ! -f $OVMS_INTERFACE_FILE ]; then
+        echo "Python Bridge start script not avaliable"
+        exit -1
+    else
+        echo "Ready for remote inferencing"
+        if [[ ! -z "$1" ]]; then
+                echo "start infer using device $1"
+                python3 $SERVER_FILE --serving_mounted_modelDir $MODEL_DIR/ --interface ovtk --vsock true --remote 50059 --device $1
+        else
+                echo "start infer using AUTO"
+                python3 $SERVER_FILE --serving_mounted_modelDir $MODEL_DIR/ --interface ovtk --vsock true --remote 50059
+        fi
+    fi
+}
+
+#-------------    main processes    -------------
+
+run_python_utility $1
+
+#!/bin/bash

--- a/scripts/setup_ai_dispatcher.sh
+++ b/scripts/setup_ai_dispatcher.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Intel Corporation.
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -eE
+
+#---------      Global variable     -------------------
+CIV_WORK_DIR=$(pwd)
+AI_DISPATCHER_DIR=$CIV_WORK_DIR/ai-dispatcher
+MODEL_DIR=$AI_DISPATCHER_DIR/model
+CLIENT_REQ_FILE=client_requirements.txt
+GRPC_PATH=$CIV_WORK_DIR/grpc
+
+#---------      Functions      -------------------
+function install_pre_requisites() {
+    apt update
+    apt-get install -y git python3 python-dev
+    export PYTHONPATH="$HOME/.local/bin:${PYTHONPATH}"
+
+    if [ ! -x "$(command -v pip3)" ]; then
+        echo " Installing Python-pip"
+        apt-get -y install python3-pip
+    fi
+
+    version=$(pip3 -V 2>&1 | grep -Po '(?<=pip )\d+')
+    if [ "$version" -lt "23" ]; then
+        echo "Upgrading Python-pip version"
+        pip3 install --upgrade pip
+    fi
+
+    python3 -m pip install --ignore-installed six openvino-dev==2022.3.0
+    echo "Installing pre-requisites"
+}
+
+function setup_ai_dispatcher() {
+    echo "Setting up ai-dispatcher....."
+    if [ ! -e "$AI_DISPATCHER_DIR" ]; then
+        git clone https://github.com/projectceladon/ai-dispatcher.git $AI_DISPATCHER_DIR
+    fi
+
+    cd $AI_DISPATCHER_DIR
+    if [ ! -e "$AI_DISPATCHER_DIR/$CLIENT_REQ_FILE" ]; then
+        echo "Client Requirement file to enable remote inferencing not present"
+        exit -1
+    fi
+
+    echo "Downloading client_requirement.txt"
+    python3 -m pip install -r $AI_DISPATCHER_DIR/$CLIENT_REQ_FILE
+
+    echo "create model directory"
+    if [ -d "$MODEL_DIR" ]; then
+        rm -rfd $MODEL_DIR
+    fi
+    mkdir -p $MODEL_DIR
+
+    echo "Checking for environment PYTHON PATH"
+    a=`grep -rn "PYTHONPATH\=\".*ai-dispatcher.*\"" /home/$SUDO_USER/.bashrc`
+    b=`grep -rn "PYTHONPATH" /home/$SUDO_USER/.bashrc`
+    if [ -z "$b" ]; then
+        echo "export PYTHONPATH="$PYTHONPATH:$HOME/.local/bin:$AI_DISPATCHER_DIR"" | sudo tee -a $HOME/.bashrc
+    elif [ -z "$a" ]; then
+        sed -i "s|PYTHONPATH.*||g" $HOME/.bashrc
+        echo "export PYTHONPATH="$PYTHONPATH:$HOME/.local/bin:$AI_DISPATCHER_DIR"" | sudo tee -a $HOME/.bashrc
+    fi
+    chown -R $SUDO_USER:$SUDO_USER $AI_DISPATCHER_DIR
+}
+
+function setup_grpc() {
+    echo "Installing grpc with vsock support....."
+    if [ ! -e "$GRPC_PATH" ]; then
+        git clone -b v1.46.2 https://github.com/grpc/grpc.git $GRPC_PATH && cd $GRPC_PATH
+        git submodule update --init
+        echo "applying vsock patch"
+        git apply -3<$CIV_WORK_DIR/patches/grpc-host/0001-support-vsock-v1.46.2.patch
+        cd $GRPC_PATH/third_party/zlib
+        echo "applying zlip patch"
+        git apply -3<$CIV_WORK_DIR/patches/grpc-host/0002-Fix-a-bug-when-getting-a-gzip-header-extra-field-wit.patch
+        cd $GRPC_PATH
+    else
+        cd $GRPC_PATH
+        echo "grpc repo already cloned, skipping cloning..."
+    fi
+    pip3 install -r requirements.txt
+    GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip3 install .
+    cd $CIV_WORK_DIR
+}
+
+function check_env_proxy() {
+    a=`grep -rn "no_proxy\=\".*localhost.*\"" $HOME/.bashrc`
+    b=`grep -rn "no_proxy" $HOME/.bashrc`
+    echo "Checking for environment no_proxy settings"
+
+    if [ -z "$b" ]; then
+        echo "export no_proxy=\"localhost\"" | sudo tee -a $HOME/.bashrc
+    elif [ -z "$a" ]; then
+        sed -i "s|export no_proxy.*||g" $HOME/.bashrc
+        echo "export no_proxy=\"$no_proxy,localhost\"" | sudo tee -a $HOME/.bashrc
+    fi
+}
+
+function setup_gpu_drivers() {
+    echo "setting up gpu drivers"
+    sudo mkdir -p $CIV_WORK_DIR/neo && cd $CIV_WORK_DIR/neo
+    wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.13230.7/intel-igc-core_1.0.13230.7_amd64.deb
+    wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.13230.7/intel-igc-opencl_1.0.13230.7_amd64.deb
+    wget https://github.com/intel/compute-runtime/releases/download/23.05.25593.11/intel-level-zero-gpu-dbgsym_1.3.25593.11_amd64.ddeb
+    wget https://github.com/intel/compute-runtime/releases/download/23.05.25593.11/intel-level-zero-gpu_1.3.25593.11_amd64.deb
+    wget https://github.com/intel/compute-runtime/releases/download/23.05.25593.11/intel-opencl-icd-dbgsym_23.05.25593.11_amd64.ddeb
+    wget https://github.com/intel/compute-runtime/releases/download/23.05.25593.11/intel-opencl-icd_23.05.25593.11_amd64.deb
+    wget https://github.com/intel/compute-runtime/releases/download/23.05.25593.11/libigdgmm12_22.3.0_amd64.deb
+    dpkg -i *.deb
+    cd $CIV_WORK_DIR
+    rm -rfd $CIV_WORK_DIR/neo
+}
+
+function setup_infer_service() {
+    echo "Adding AI-Dispatcher rawTensor Service"
+    touch /lib/systemd/system/ai_raw_tensor.service
+
+    cat << EOF | tee /lib/systemd/system/ai_raw_tensor.service
+[Unit]
+Description="Start/Stop Remote Inferencing"
+
+[Service]
+User=$SUDO_USER
+WorkingDirectory=$(pwd)/
+Type=simple
+ExecStart=/bin/bash ./scripts/ai_raw_tensor.sh $1
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl enable ai_raw_tensor
+    systemctl daemon-reload
+    systemctl start ai_raw_tensor
+    echo "Starting Remote Inferencing Setup Script"
+}
+
+#-------------    main processes    -------------
+
+check_env_proxy
+install_pre_requisites
+setup_ai_dispatcher
+setup_grpc
+if [ $1 =~ "GPU" -o $1 == "AUTO" ]; then
+    setup_gpu_drivers
+fi
+setup_infer_service $1
+
+echo "remote infer installation done"
+#!/bin/bash

--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -320,6 +320,13 @@ function ubu_update_fw(){
     reboot_required=1
 }
 
+function setup_remote_infer() {
+    echo "setting up remote inference"
+    source $CIV_WORK_DIR/scripts/setup_ai_dispatcher.sh $1
+    reboot_required=1
+    cd $CIV_WORK_DIR
+}
+
 function check_os() {
     local version=`cat /proc/version`
 
@@ -597,6 +604,7 @@ function show_help() {
     printf "\t-h  show this help message\n"
     printf "\t-u  specify Host OS's UI, support \"headless\" and \"GUI\" eg. \"-u headless\" or \"-u GUI\"\n"
     printf "\t--auto-start auto start CiV guest when Host boot up.\n"
+    printf "\t-i  enable remote inferencing with specific device\n"
 }
 
 function parse_arg() {
@@ -624,6 +632,11 @@ function parse_arg() {
 
             -t)
                 start_thermal_daemon || return -1
+                ;;
+
+            -i)
+                setup_remote_infer $2 || return -1
+                shift
                 ;;
 
             --auto-start)


### PR DESCRIPTION
add remote inference in civ host as a service.

Adds scripts to setup and start raw tensor service on host.

To setup ai-dispatcher, while doing host setup use "sudo -E ./scripts/setup_host.sh -i <device name>" <device name> can be CPU,GPU,GPU.0,GPU.1

For using GPU launch civ using SRIOV

Tracked-On: OAM-108910