### PR TITLE
Use dynamic user id in vm manager pulse audio

### DIFF
--- a/src/guest/vm_builder_qemu.cc
+++ b/src/guest/vm_builder_qemu.cc
@@ -514,7 +514,8 @@ void VmBuilderQemu::BuildAudioCmd(void) {
     emul_cmd_.append(" -device intel-hda"
                      " -device hda-duplex,audiodev=android_spk"
                      " -audiodev id=android_spk,timer-period=5000,driver=pa,"
-                     "in.fixed-settings=off,out.fixed-settings=off,server=/run/user/1000/pulse/native");
+                     "in.fixed-settings=off,out.fixed-settings=off,server=/run/user/" + std::to_string(uid) +
+                     "/pulse/native");
 }
 
 void VmBuilderQemu::BuildExtraCmd(void) {


### PR DESCRIPTION
User id is hardcoded to 1000, this is not correct and causes issue when user id is different.

Tracked-On: OAM-111764