### PR TITLE
Bring down Bluetooth HCI interface before passthrough

### DIFF
--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -15,6 +15,11 @@
 #define CIV_GUEST_QMP_SUFFIX     ".qmp.unix.socket"
 
 const char *GetConfigPath(void);
+std::string runCommand(const char* cmd);
+bool extractBusDevice(const std::string& input, std::string& bus, std::string& device);
+std::string getBluetoothAddress(std::string output);
+std::string checkIntelDeviceId();
+
 int Daemonize(void);
 
 constexpr std::size_t operator""_KB(unsigned long long v) {


### PR DESCRIPTION
Every time before launching android user has to manually
do "sudo hciconfig hci0 down" when BT Card is passthrough.

We are dynamically fetching the Intel BT-Card Pci address and
bringing down Bluetooth HCI interface before the passthrough.

Tests done:
1. Build vm-manager binary
2. Launch android using this binary with BT-Passthrough in .ini
3. Check the Android BT On Success every time.
4. Validated Steps 2 & 3 on RPL NUC, MTL board with/without passthrough
5. Validated Steps 2 & 3 on MTL board with/without BT-Card

Tracked-On: OAM-116593
Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
Signed-off-by: Aman Bhadouria <aman.bhadouria@intel.com>