### PR TITLE
Add Blutooth Hci interface down option

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -169,3 +169,6 @@ Requirements
 - cmd: Set extra command.
 - service: Set extra services, use `:` split different services.
 - pwr_ctrl_multios: If set to "true", will create qmp socket in /tmp/ folder for suspend/hibernate feature. Setting to "false" will not create the sockeet.
+
+### [bluetooth]
+- hci_down: If set to 'true', will bring down Bluetooth Hci Interface. Make sure BT USB Pci address is added in `[passthrough]`.

--- a/src/guest/config_parser.cc
+++ b/src/guest/config_parser.cc
@@ -41,6 +41,7 @@ map<string_view, vector<string_view>> kConfigMap = {
     { kGroupRpmb,    { kRpmbBinPath, kRpmbDataDir } },
     { kGroupAaf,     { kAafPath, kAafSuspend, kAafAudioType }},
     { kGroupPciPt,   { kPciPtDev }},
+    { kGroupbluetooth, { kHciDown }},
     { kGroupAudio,   { kDisableEmul } },
     { kGroupMed,     { kMedBattery, kMedThermal, kMedCamera } },
     { kGroupService, { kServTimeKeep, kServPmCtrl, kServVinput } },

--- a/src/guest/config_parser.h
+++ b/src/guest/config_parser.h
@@ -28,6 +28,7 @@ constexpr char kGroupVtpm[]    = "vtpm";
 constexpr char kGroupRpmb[]    = "rpmb";
 constexpr char kGroupAaf[]     = "aaf";
 constexpr char kGroupPciPt[]   = "passthrough";
+constexpr char kGroupbluetooth[] = "bluetooth";
 constexpr char kGroupAudio[]   = "audio";
 constexpr char kGroupMed[]     = "mediation";
 constexpr char kGroupService[] = "guest_control";
@@ -77,6 +78,8 @@ constexpr char kAafSuspend[] = "support_suspend";
 constexpr char kAafAudioType[] = "audio_type";
 
 constexpr char kPciPtDev[] = "passthrough_pci";
+
+constexpr char kHciDown[] = "hci_down";
 
 constexpr char kDisableEmul[] = "disable_emulation";
 

--- a/src/guest/vm_builder_qemu.h
+++ b/src/guest/vm_builder_qemu.h
@@ -57,6 +57,7 @@ class VmBuilderQemu : public VmBuilder {
     void BuildVcpuCmd(void);
     bool BuildFirmwareCmd(void);
     void BuildVdiskCmd(void);
+    void BringDownBtHciIntf(void);
     void BuildPtPciDevicesCmd(void);
     void BuildGuestTimeKeepCmd(void);
     void BuildGuestPmCtrlCmd(void);


### PR DESCRIPTION
Everytime before launching android user has to manually do "sudo hciconfig hci0 down" when BT Card is passthrough.

Added 'bluetooth' section with 'hci_down' flag in the vm-manager. If set to 'true', will bring down the BT hci interface.

Tests done:
1. Build vm-manager binary
2. Add BT USB Pci address in the [passthrough]
3. Add hci_down=true in [bluetooth]
4. Launch Android and check BT on success
5. Validated on RPL NUC with AX211

Tracked-On: OAM-116593