### PR TITLE
Fix permission issue of release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,11 @@ name: VM Manager Release
 on:
   release:
     types: [published, edited]
-permissions: write-all
+permissions: read-all
 jobs:
   build_ubuntu_gcc:
-
+    permissions:
+      contents: write
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Change write-all to read-all from top level.
Add contents:write for build_ubuntu_gcc which required by action-gh-release.

Signed-off-by: YadongQi <yadong.qi@intel.com>